### PR TITLE
[DELIVERS #156936832] FactorySql

### DIFF
--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -11,11 +11,11 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -34,20 +34,20 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "AND foo.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           ",",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -59,11 +59,11 @@ describe("FactorySql", () => {
       SqlComposer.Select.(
         select
         |> modifier(`Distinct)
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -82,20 +82,20 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "AND foo.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           ",",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -106,11 +106,11 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -130,20 +130,20 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "AND foo.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           ",",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -154,10 +154,10 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -177,19 +177,19 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
           "AND foo.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           ",",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -200,11 +200,11 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -223,19 +223,19 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           ",",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -246,10 +246,10 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -268,17 +268,17 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "ORDER BY",
           "  foo.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -289,11 +289,11 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
-        |> group_by("test.id")
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -311,17 +311,17 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           "GROUP BY",
-          "  test.id",
+          "  animal.id",
           ",   foo.id",
           "LIMIT 1 OFFSET 0",
         ],
@@ -332,10 +332,10 @@ describe("FactorySql", () => {
     let base =
       SqlComposer.Select.(
         select
-        |> field("test.id")
-        |> join("JOIN blah ON blah.id = test.blah_id")
-        |> where("AND test.deleted IS NULL")
-        |> order_by(`Asc("test.id"))
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
         |> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
@@ -353,17 +353,58 @@ describe("FactorySql", () => {
         "\n",
         [
           "SELECT DISTINCT",
-          "  test.id",
+          "  animal.id",
           "  ,   foo.id",
           "FROM `animal`",
-          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN blah ON blah.id = animal.blah_id",
           "JOIN foo ON foo.id = blah.foo_id",
           "WHERE 1=1",
-          "AND test.deleted IS NULL",
+          "AND animal.deleted IS NULL",
           "ORDER BY",
-          "  test.id ASC",
+          "  animal.id ASC",
           "GROUP BY",
           "  foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
+  test("make (no user group by clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  animal.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = animal.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND animal.deleted IS NULL",
+          "ORDER BY",
+          "  animal.id ASC",
+          "GROUP BY",
+          "  animal.id",
           "LIMIT 1 OFFSET 0",
         ],
       );

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -242,4 +242,47 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no base order by clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "ORDER BY",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -6,27 +6,27 @@ external animalToJson : animal => Js.Json.t = "%identity";
 
 let table = "animal";
 
+let (>>): ('a => 'b, 'b => 'c, 'a) => 'c = (f, g, x) => g(f(x));
+
 describe("FactorySql", () => {
   test("make (merging all clauses from base and user)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> where("AND foo.deleted IS NULL")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> where("AND foo.deleted IS NULL")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -57,24 +57,22 @@ describe("FactorySql", () => {
   test("make (with base modifier)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> where("AND foo.deleted IS NULL")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> where("AND foo.deleted IS NULL")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -105,24 +103,22 @@ describe("FactorySql", () => {
   test("make (with user modifier)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> where("AND foo.deleted IS NULL")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> where("AND foo.deleted IS NULL")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -153,23 +149,21 @@ describe("FactorySql", () => {
   test("make (no base where clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> where("AND foo.deleted IS NULL")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> where("AND foo.deleted IS NULL")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -199,23 +193,21 @@ describe("FactorySql", () => {
   test("make (no user where clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -245,22 +237,20 @@ describe("FactorySql", () => {
   test("make (no base order by clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> order_by(`Asc("foo.id"))
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> order_by(`Asc("foo.id"))
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -288,22 +278,20 @@ describe("FactorySql", () => {
   test("make (no user order by clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -331,21 +319,19 @@ describe("FactorySql", () => {
   test("make (no base group by clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> group_by("foo.id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> group_by("foo.id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -372,21 +358,19 @@ describe("FactorySql", () => {
   test("make (no user group by clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -413,20 +397,18 @@ describe("FactorySql", () => {
   test("make (no base limit clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
-        |> limit(~offset="5", ~row_count=Some(1))
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
+        >> limit(~offset="5", ~row_count=Some(1))
       );
     let output = FactorySql.make(table, base, user);
     let expected =
@@ -453,20 +435,18 @@ describe("FactorySql", () => {
   test("make (no user limit clause)", () => {
     let base =
       SqlComposer.Select.(
-        select
-        |> field("animal.id")
-        |> join("JOIN blah ON blah.id = animal.blah_id")
-        |> where("AND animal.deleted IS NULL")
-        |> order_by(`Asc("animal.id"))
-        |> group_by("animal.id")
-        |> limit(~offset="0", ~row_count=Some(1))
+        field("animal.id")
+        >> join("JOIN blah ON blah.id = animal.blah_id")
+        >> where("AND animal.deleted IS NULL")
+        >> order_by(`Asc("animal.id"))
+        >> group_by("animal.id")
+        >> limit(~offset="0", ~row_count=Some(1))
       );
     let user =
       SqlComposer.Select.(
-        select
-        |> modifier(`Distinct)
-        |> field("foo.id")
-        |> join("JOIN foo ON foo.id = blah.foo_id")
+        modifier(`Distinct)
+        >> field("foo.id")
+        >> join("JOIN foo ON foo.id = blah.foo_id")
       );
     let output = FactorySql.make(table, base, user);
     let expected =

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -410,4 +410,44 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no base limit clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  animal.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = animal.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND animal.deleted IS NULL",
+          "ORDER BY",
+          "  animal.id ASC",
+          "GROUP BY",
+          "  animal.id",
+          "LIMIT 1 OFFSET 5",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -28,7 +28,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -74,7 +75,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -120,7 +122,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -165,7 +168,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -209,7 +213,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -252,7 +257,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -293,7 +299,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -333,7 +340,8 @@ describe("FactorySql", () => {
         >> group_by("foo.id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -372,7 +380,8 @@ describe("FactorySql", () => {
         >> join("JOIN foo ON foo.id = blah.foo_id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -410,7 +419,8 @@ describe("FactorySql", () => {
         >> join("JOIN foo ON foo.id = blah.foo_id")
         >> limit(~offset="5", ~row_count=Some(1))
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -448,7 +458,8 @@ describe("FactorySql", () => {
         >> field("foo.id")
         >> join("JOIN foo ON foo.id = blah.foo_id")
       );
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",
@@ -473,7 +484,8 @@ describe("FactorySql", () => {
   test("make (only select)", () => {
     let base = SqlComposer.Select.field("animal.id");
     let user = SqlComposer.Select.field("animal.type");
-    let output = FactorySql.make(table, base, user);
+    let output =
+      FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
     let expected =
       String.concat(
         "\n",

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -196,4 +196,50 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no user where clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          ",",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -349,7 +349,7 @@ describe("FactorySql", () => {
           "ORDER BY",
           "  animal.id ASC",
           "GROUP BY",
-          "  foo.id",
+          "    foo.id",
           "LIMIT 1 OFFSET 0",
         ],
       );
@@ -468,6 +468,14 @@ describe("FactorySql", () => {
           "LIMIT 1 OFFSET 0",
         ],
       );
+    output == expected ? pass : fail("not expected output");
+  });
+  test("make (only select)", () => {
+    let base = SqlComposer.Select.field("*");
+    let user = (_) => SqlComposer.Select.select;
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat("\n", ["SELECT", "  *", "FROM `animal`", "WHERE 1=1"]);
     output == expected ? pass : fail("not expected output");
   });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -1,0 +1,63 @@
+open Jest;
+
+type animal = {type_: string};
+
+external animalToJson : animal => Js.Json.t = "%identity";
+
+let table = "animal";
+
+describe("FactorySql", () =>
+  test("make (merging all clauses from base and user)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> where("AND foo.deleted IS NULL")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "AND foo.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          ",",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    Js.log({j|$output|j});
+    Js.log(expected);
+    if (output == expected) {
+      pass;
+    } else {
+      fail("not expected output");
+    };
+  })
+);

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -6,7 +6,55 @@ external animalToJson : animal => Js.Json.t = "%identity";
 
 let table = "animal";
 
-describe("FactorySql", () =>
+describe("FactorySql", () => {
+  test("make (base modifier)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> where("AND foo.deleted IS NULL")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "AND foo.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          ",",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
   test("make (merging all clauses from base and user)", () => {
     let base =
       SqlComposer.Select.(
@@ -52,12 +100,6 @@ describe("FactorySql", () =>
           "LIMIT 1 OFFSET 0",
         ],
       );
-    Js.log({j|$output|j});
-    Js.log(expected);
-    if (output == expected) {
-      pass;
-    } else {
-      fail("not expected output");
-    };
-  })
-);
+    output == expected ? pass : fail("not expected output");
+  });
+});

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -150,4 +150,50 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no base where clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> where("AND foo.deleted IS NULL")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND foo.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          ",",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -450,4 +450,44 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no user limit clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("animal.id")
+        |> join("JOIN blah ON blah.id = animal.blah_id")
+        |> where("AND animal.deleted IS NULL")
+        |> order_by(`Asc("animal.id"))
+        |> group_by("animal.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  animal.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = animal.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND animal.deleted IS NULL",
+          "ORDER BY",
+          "  animal.id ASC",
+          "GROUP BY",
+          "  animal.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -7,6 +7,54 @@ external animalToJson : animal => Js.Json.t = "%identity";
 let table = "animal";
 
 describe("FactorySql", () => {
+  test("make (user modifier)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> where("AND foo.deleted IS NULL")
+        |> order_by(`Asc("foo.id"))
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "AND foo.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          ",",
+          "  foo.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
   test("make (base modifier)", () => {
     let base =
       SqlComposer.Select.(

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -471,11 +471,20 @@ describe("FactorySql", () => {
     output == expected ? pass : fail("not expected output");
   });
   test("make (only select)", () => {
-    let base = SqlComposer.Select.field("*");
-    let user = (_) => SqlComposer.Select.select;
+    let base = SqlComposer.Select.field("animal.id");
+    let user = SqlComposer.Select.field("animal.type");
     let output = FactorySql.make(table, base, user);
     let expected =
-      String.concat("\n", ["SELECT", "  *", "FROM `animal`", "WHERE 1=1"]);
+      String.concat(
+        "\n",
+        [
+          "SELECT",
+          "  animal.id",
+          "  ,   animal.type",
+          "FROM `animal`",
+          "WHERE 1=1",
+        ],
+      );
     output == expected ? pass : fail("not expected output");
   });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -328,4 +328,45 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no base group by clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          "GROUP BY",
+          "  foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -285,4 +285,47 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
+  test("make (no user order by clause)", () => {
+    let base =
+      SqlComposer.Select.(
+        select
+        |> field("test.id")
+        |> join("JOIN blah ON blah.id = test.blah_id")
+        |> where("AND test.deleted IS NULL")
+        |> order_by(`Asc("test.id"))
+        |> group_by("test.id")
+        |> limit(~offset="0", ~row_count=Some(1))
+      );
+    let user =
+      SqlComposer.Select.(
+        select
+        |> modifier(`Distinct)
+        |> field("foo.id")
+        |> join("JOIN foo ON foo.id = blah.foo_id")
+        |> group_by("foo.id")
+        |> limit(~offset="5", ~row_count=Some(1))
+      );
+    let output = FactorySql.make(table, base, user);
+    let expected =
+      String.concat(
+        "\n",
+        [
+          "SELECT DISTINCT",
+          "  test.id",
+          "  ,   foo.id",
+          "FROM `animal`",
+          "JOIN blah ON blah.id = test.blah_id",
+          "JOIN foo ON foo.id = blah.foo_id",
+          "WHERE 1=1",
+          "AND test.deleted IS NULL",
+          "ORDER BY",
+          "  test.id ASC",
+          "GROUP BY",
+          "  test.id",
+          ",   foo.id",
+          "LIMIT 1 OFFSET 0",
+        ],
+      );
+    output == expected ? pass : fail("not expected output");
+  });
 });

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -7,7 +7,7 @@ external animalToJson : animal => Js.Json.t = "%identity";
 let table = "animal";
 
 describe("FactorySql", () => {
-  test("make (user modifier)", () => {
+  test("make (merging all clauses from base and user)", () => {
     let base =
       SqlComposer.Select.(
         select
@@ -21,7 +21,6 @@ describe("FactorySql", () => {
     let user =
       SqlComposer.Select.(
         select
-        |> modifier(`Distinct)
         |> field("foo.id")
         |> join("JOIN foo ON foo.id = blah.foo_id")
         |> where("AND foo.deleted IS NULL")
@@ -34,7 +33,7 @@ describe("FactorySql", () => {
       String.concat(
         "\n",
         [
-          "SELECT DISTINCT",
+          "SELECT",
           "  test.id",
           "  ,   foo.id",
           "FROM `animal`",
@@ -103,7 +102,7 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
-  test("make (merging all clauses from base and user)", () => {
+  test("make (user modifier)", () => {
     let base =
       SqlComposer.Select.(
         select
@@ -117,6 +116,7 @@ describe("FactorySql", () => {
     let user =
       SqlComposer.Select.(
         select
+        |> modifier(`Distinct)
         |> field("foo.id")
         |> join("JOIN foo ON foo.id = blah.foo_id")
         |> where("AND foo.deleted IS NULL")
@@ -129,7 +129,7 @@ describe("FactorySql", () => {
       String.concat(
         "\n",
         [
-          "SELECT",
+          "SELECT DISTINCT",
           "  test.id",
           "  ,   foo.id",
           "FROM `animal`",

--- a/__tests__/TestFactorySql.re
+++ b/__tests__/TestFactorySql.re
@@ -54,7 +54,7 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
-  test("make (base modifier)", () => {
+  test("make (with base modifier)", () => {
     let base =
       SqlComposer.Select.(
         select
@@ -102,7 +102,7 @@ describe("FactorySql", () => {
       );
     output == expected ? pass : fail("not expected output");
   });
-  test("make (user modifier)", () => {
+  test("make (with user modifier)", () => {
     let base =
       SqlComposer.Select.(
         select

--- a/src/FactorySql.re
+++ b/src/FactorySql.re
@@ -1,17 +1,17 @@
 /* Private */
+let removeLastItemInList = list =>
+  switch (List.tl @@ list) {
+  | exception _ => []
+  | result => result
+  };
+
 let mergeGroupBy = (base, userClauses) =>
   SqlComposer.Select.(
-    if (List.length(userClauses) == 0) {
-      base.group_by;
-    } else if (List.length(base.group_by) == 0) {
-      userClauses;
-    } else {
-      userClauses
-      |> List.rev
-      |> List.tl
-      |> List.fold_left((acc, x) => group_by(x, acc), base)
-      |> (x => x.group_by);
-    }
+    userClauses
+    |> List.rev
+    |> removeLastItemInList
+    |> List.fold_left((acc, x) => group_by(x, acc), base)
+    |> (x => x.group_by)
   );
 
 let mergeOrderBy = (baseClauses, userClauses) =>
@@ -22,7 +22,7 @@ let mergeOrderBy = (baseClauses, userClauses) =>
   } else {
     userClauses
     |> List.rev
-    |> List.tl
+    |> removeLastItemInList
     |> (x => List.concat([x, [","], baseClauses]));
   };
 
@@ -30,7 +30,7 @@ let mergeWhere = (base, userClauses) =>
   SqlComposer.Select.(
     userClauses
     |> List.rev
-    |> List.tl
+    |> removeLastItemInList
     |> List.fold_left((acc, x) => where(x, acc), base)
     |> (x => x.where)
   );

--- a/src/FactorySql.re
+++ b/src/FactorySql.re
@@ -1,0 +1,50 @@
+/* Private */
+let mergeOrderBy = (baseClauses, userClauses) =>
+  if (List.length(userClauses) == 0) {
+    baseClauses;
+  } else if (List.length(baseClauses) == 0) {
+    userClauses;
+  } else {
+    userClauses
+    |> List.rev
+    |> List.tl
+    |> (x => List.concat([x, [","], baseClauses]));
+  };
+
+let merge = (base, user, baseClauses, userClauses, fn) =>
+  if (List.length(userClauses) == 0) {
+    base;
+  } else if (List.length(baseClauses) == 0) {
+    user;
+  } else {
+    userClauses
+    |> List.rev
+    |> List.tl
+    |> List.fold_left((acc, x) => fn(x, acc), base);
+  };
+
+let mergeFields = (base, clauses) =>
+  List.fold_left(
+    (acc, x) => SqlComposer.Select.field(x, acc),
+    base,
+    clauses,
+  );
+
+let factory = (table, base, user) =>
+  SqlComposer.Select.(
+    {
+      modifier: base.modifier != None ? base.modifier : user.modifier,
+      fields: mergeFields(base, user.fields).fields,
+      from: [{j|FROM `$table`|j}],
+      join: List.concat([user.join, base.join]),
+      where: merge(base, user, base.where, user.where, where).where,
+      order_by: mergeOrderBy(base.order_by, user.order_by),
+      group_by:
+        merge(base, user, base.group_by, user.group_by, group_by).group_by,
+      limit: List.length(base.limit) > 0 ? base.limit : user.limit,
+    }
+    |> to_sql
+  );
+
+/* Public */
+let make = (table, base, user) => factory(table, base, user);

--- a/src/FactorySql.re
+++ b/src/FactorySql.re
@@ -56,6 +56,10 @@ let factory = (table, base, user) =>
   );
 
 /* Public */
+/* @TODO - the base and user functions don't necessarily need to user
+   the SqlComposer.Select.select type defined locally, figure out
+   how to change this so that we will always know exactly what goes
+   into the base and user function.*/
 let make = (table, base, user) =>
   factory(
     table,

--- a/src/FactorySql.re
+++ b/src/FactorySql.re
@@ -41,19 +41,16 @@ let mergeFields = (base, userClauses) =>
   |> (x => x.fields);
 
 let factory = (table, base, user) =>
-  SqlComposer.Select.(
-    {
-      modifier: base.modifier != None ? base.modifier : user.modifier,
-      fields: mergeFields(base, user.fields),
-      from: [{j|FROM `$table`|j}],
-      join: List.concat([user.join, base.join]),
-      where: mergeWhere(base, user.where),
-      order_by: mergeOrderBy(base.order_by, user.order_by),
-      group_by: mergeGroupBy(base, user.group_by),
-      limit: List.length(base.limit) > 0 ? base.limit : user.limit,
-    }
-    |> to_sql
-  );
+  SqlComposer.Select.{
+    modifier: base.modifier != None ? base.modifier : user.modifier,
+    fields: mergeFields(base, user.fields),
+    from: [{j|FROM `$table`|j}],
+    join: List.concat([user.join, base.join]),
+    where: mergeWhere(base, user.where),
+    order_by: mergeOrderBy(base.order_by, user.order_by),
+    group_by: mergeGroupBy(base, user.group_by),
+    limit: List.length(base.limit) > 0 ? base.limit : user.limit,
+  };
 
 /* Public */
 /* @TODO - the base and user functions don't necessarily need to user

--- a/src/FactorySql.rei
+++ b/src/FactorySql.rei
@@ -1,0 +1,5 @@
+let make: (
+  string,
+  SqlComposer.Select.t,
+  SqlComposer.Select.t,
+) => (string);

--- a/src/FactorySql.rei
+++ b/src/FactorySql.rei
@@ -1,5 +1,5 @@
 let make: (
   string,
-  SqlComposer.Select.t,
-  SqlComposer.Select.t,
+  SqlComposer.Select.t => SqlComposer.Select.t,
+  SqlComposer.Select.t => SqlComposer.Select.t,
 ) => (string);

--- a/src/FactorySql.rei
+++ b/src/FactorySql.rei
@@ -2,4 +2,4 @@ let make: (
   string,
   SqlComposer.Select.t => SqlComposer.Select.t,
   SqlComposer.Select.t => SqlComposer.Select.t,
-) => (string);
+) => SqlComposer.Select.t;


### PR DESCRIPTION
## Summary of the major changes in this PR:

- New: added `src/FactorySql.re`.
- New: added `src/FactorySql.rei`.
- New: added `__tests__/TestFactorySql.re`; test coverage for the make function in its various states have been added.

## Things of note:

- The base and user functions don't necessarily need to user the SqlComposer.Select.select type defined locally, figure out how to change this so that we will always know exactly what goes into the base and user function. For example nothing stops the following:
```
...

let base = (_) => { ...SqlComposer.Select.select, modifier: None, fields: ["SELECT *"], where: ["AND animal.deleted IS NULL"]};

...

let output = FactorySql.make(table, base, user) |> SqlComposer.Select.to_sql;
```