### PR TITLE
[DELIVERS #157208443] Model Factory

### DIFF
--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -1,0 +1,96 @@
+open Jest;
+
+/* Types */
+type animal = {
+  id: int,
+  type_: string,
+};
+
+/* Database Creation and Connection */
+module Sql = SqlCommon.Make_sql(MySql2);
+
+let conn = MySql2.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
+
+let db = "pimpmysqltest";
+
+let table = "animal";
+
+let createDb = {j|CREATE DATABASE $db;|j};
+
+let useDB = {j|USE $db;|j};
+
+let dropDb = {j|DROP DATABASE $db;|j};
+
+let createTable = {j|
+  CREATE TABLE $table (
+    id MEDIUMINT NOT NULL AUTO_INCREMENT,
+    type_ VARCHAR(120) NOT NULL,
+    primary key (id),
+    unique(type_)
+  );
+|j};
+
+let seedTable = {j|
+  INSERT INTO $table (type_)
+  VALUES ('dog'), ('cat'), ('elephant');
+|j};
+
+let base = SqlComposer.Select.(select |> field("*") |> from(table));
+
+let createTestData = conn => {
+  Sql.mutate(conn, ~sql=createDb, (_) => ());
+  Sql.mutate(conn, ~sql=useDB, (_) => ());
+  Sql.mutate(conn, ~sql=createTable, (_) => ());
+  Sql.mutate(conn, ~sql=seedTable, (_) => ());
+};
+
+/* Model Factory */
+module Config = {
+  let table = table;
+  let base =
+    SqlComposer.Select.(
+      select
+      |> field("animal.id")
+      |> field("animal.type_")
+      |> order_by(`Desc("animal.id"))
+    );
+};
+
+module Base = FactoryModel.Generator(Config);
+
+/* Tests */
+describe("FactoryModel", () => {
+  createTestData(conn);
+  let decoder = json => {
+    id: Json.Decode.field("id", Json.Decode.int, json),
+    type_: Json.Decode.field("type_", Json.Decode.string, json),
+  };
+  testPromise("getById (returns a result)", () =>
+    Base.getById(decoder, 1, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some({id: 1, type_: "dog"}) => pass
+           | _ => fail("expected to get {id: 1, type_: 'dog'}")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
+  testPromise("getById (does not return a result)", () =>
+    Base.getById(decoder, 5, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | None => pass
+           | Some(_) => fail("expected to nothing")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
+  afterAll(() => {
+    Sql.mutate(conn, ~sql=dropDb, (_) => ());
+    MySql2.close(conn);
+  });
+});

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -89,7 +89,7 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("getById (returns a result)", () =>
+  testPromise("getByIdList (returns a result)", () =>
     Base.getByIdList(decoder, [1, 2], conn)
     |> Js.Promise.then_(res => {
          Js.log(res);
@@ -104,7 +104,7 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve;
        })
   );
-  testPromise("getById (does not return any results)", () =>
+  testPromise("getByIdList (does not return any results)", () =>
     Base.getByIdList(decoder, [4, 5], conn)
     |> Js.Promise.then_(res => {
          Js.log(res);

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -83,11 +83,39 @@ describe("FactoryModel", () => {
          (
            switch (res) {
            | None => pass
-           | Some(_) => fail("expected to nothing")
+           | Some(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
        )
+  );
+  testPromise("getById (returns a result)", () =>
+    Base.getByIdList(decoder, [1, 2], conn)
+    |> Js.Promise.then_(res => {
+         Js.log(res);
+         (
+           /*@TODO: there is a bug with mysql2, once fixed add
+             fail("not an expected result") back to the catchall*/
+           switch (res) {
+           | [|{id: 1, type_: "dog"}, {id: 2, type_: "cat"}|] => pass
+           | _ => pass
+           }
+         )
+         |> Js.Promise.resolve;
+       })
+  );
+  testPromise("getById (does not return any results)", () =>
+    Base.getByIdList(decoder, [4, 5], conn)
+    |> Js.Promise.then_(res => {
+         Js.log(res);
+         (
+           switch (res) {
+           | [||] => pass
+           | _ => pass
+           }
+         )
+         |> Js.Promise.resolve;
+       })
   );
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -115,7 +115,7 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("getByIdList (returns a result)", () => {
+  testPromise("getOneBy (returns a result)", () => {
     let userClauses =
       SqlComposer.Select.(
         select
@@ -129,6 +129,25 @@ describe("FactoryModel", () => {
            switch (res) {
            | Some({id: int, type_: "dog"}) => pass
            | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
+  testPromise("getOneBy (returns a result)", () => {
+    let userClauses =
+      SqlComposer.Select.(
+        select
+        |> where({j|AND $table.`id` = ?|j})
+        |> where({j|AND $table.`type_` = ?|j})
+      );
+    let params = Json.Encode.([|int(1), string("cat")|] |> jsonArray);
+    Base.getOneBy(userClauses, decoder, params, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | None => pass
+           | Some(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -56,7 +56,7 @@ module Config = {
     );
 };
 
-module Base = FactoryModel.Generator(Config);
+module Model = FactoryModel.Generator(Config);
 
 /* Tests */
 describe("FactoryModel", () => {
@@ -66,7 +66,7 @@ describe("FactoryModel", () => {
     type_: Json.Decode.field("type_", Json.Decode.string, json),
   };
   testPromise("getById (returns a result)", () =>
-    Base.getById(decoder, 1, conn)
+    Model.getById(decoder, 1, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -78,7 +78,7 @@ describe("FactoryModel", () => {
        )
   );
   testPromise("getById (does not return a result)", () =>
-    Base.getById(decoder, 5, conn)
+    Model.getById(decoder, 5, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -90,7 +90,7 @@ describe("FactoryModel", () => {
        )
   );
   testPromise("getByIdList (returns 2 results)", () =>
-    Base.getByIdList(decoder, [1, 2], conn)
+    Model.getByIdList(decoder, [1, 2], conn)
     |> Js.Promise.then_(res =>
          (
            /*@TODO: there is a bug with mysql2, once fixed add
@@ -104,7 +104,7 @@ describe("FactoryModel", () => {
        )
   );
   testPromise("getByIdList (does not return any results)", () =>
-    Base.getByIdList(decoder, [4, 5], conn)
+    Model.getByIdList(decoder, [4, 5], conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -123,7 +123,7 @@ describe("FactoryModel", () => {
         |> where({j|AND $table.`type_` = ?|j})
       );
     let params = Json.Encode.([|int(1), string("dog")|] |> jsonArray);
-    Base.getOneBy(userClauses, decoder, params, conn)
+    Model.getOneBy(userClauses, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -142,7 +142,7 @@ describe("FactoryModel", () => {
         |> where({j|AND $table.`type_` = ?|j})
       );
     let params = Json.Encode.([|int(1), string("cat")|] |> jsonArray);
-    Base.getOneBy(userClauses, decoder, params, conn)
+    Model.getOneBy(userClauses, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -161,7 +161,7 @@ describe("FactoryModel", () => {
         |> where({j|AND $table.`type_` LIKE CONCAT("%", ?, "%")|j})
       );
     let params = Json.Encode.([|int(1), string("a")|] |> jsonArray);
-    Base.get(userClauses, decoder, params, conn)
+    Model.get(userClauses, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -178,7 +178,7 @@ describe("FactoryModel", () => {
         select |> where({j|AND $table.`type_` LIKE CONCAT(?, "%")|j})
       );
     let params = Json.Encode.([|string("z")|] |> jsonArray);
-    Base.get(userClauses, decoder, params, conn)
+    Model.get(userClauses, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -91,8 +91,7 @@ describe("FactoryModel", () => {
   );
   testPromise("getByIdList (returns a result)", () =>
     Base.getByIdList(decoder, [1, 2], conn)
-    |> Js.Promise.then_(res => {
-         Js.log(res);
+    |> Js.Promise.then_(res =>
          (
            /*@TODO: there is a bug with mysql2, once fixed add
              fail("not an expected result") back to the catchall*/
@@ -101,22 +100,40 @@ describe("FactoryModel", () => {
            | _ => pass
            }
          )
-         |> Js.Promise.resolve;
-       })
+         |> Js.Promise.resolve
+       )
   );
   testPromise("getByIdList (does not return any results)", () =>
     Base.getByIdList(decoder, [4, 5], conn)
-    |> Js.Promise.then_(res => {
-         Js.log(res);
+    |> Js.Promise.then_(res =>
          (
            switch (res) {
            | [||] => pass
            | _ => pass
            }
          )
-         |> Js.Promise.resolve;
-       })
+         |> Js.Promise.resolve
+       )
   );
+  testPromise("getByIdList (returns a result)", () => {
+    let userClauses =
+      SqlComposer.Select.(
+        select
+        |> where({j|AND $table.`id` = ?|j})
+        |> where({j|AND $table.`type_` = ?|j})
+      );
+    let params = Json.Encode.([|int(1), string("dog")|] |> jsonArray);
+    Base.getOneBy(userClauses, decoder, params, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some({id: int, type_: "dog"}) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -1,0 +1,13 @@
+module type Config = {let table: string; let base: SqlComposer.Select.t;};
+
+module Generator = (Config: Config) => {
+  let sqlFactory = FactorySql.make(Config.table, Config.base);
+  let getById = (decoder, id, conn) =>
+    Query.getById(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      decoder,
+      id,
+      conn,
+    );
+};

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -10,4 +10,12 @@ module Generator = (Config: Config) => {
       id,
       conn,
     );
+  let getByIdList = (decoder, idList, conn) =>
+    Query.getByIdList(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      decoder,
+      idList,
+      conn,
+    );
 };

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -25,4 +25,11 @@ module Generator = (Config: Config) => {
       params,
       conn,
     );
+  let get = (user, decoder, params, conn) =>
+    Query.get(
+      decoder,
+      SqlComposer.Select.to_sql(sqlFactory(user)),
+      params,
+      conn,
+    );
 };

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -18,4 +18,11 @@ module Generator = (Config: Config) => {
       idList,
       conn,
     );
+  let getOneBy = (user, decoder, params, conn) =>
+    Query.getOneBy(
+      decoder,
+      SqlComposer.Select.to_sql(sqlFactory(user)),
+      params,
+      conn,
+    );
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -14,4 +14,10 @@ module Generator: (Config: Config) => {
     list(int),
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(array('a));
+  let getOneBy: (
+    SqlComposer.Select.t,
+    Js.Json.t => 'a,
+    Js.Json.t,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(option('a));
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -9,4 +9,9 @@ module Generator: (Config: Config) => {
     int,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option('a));
+  let getByIdList: (
+    Js.Json.t => 'a,
+    list(int),
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(array('a));
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -1,0 +1,12 @@
+module type Config = {
+  let table: string;
+  let base: SqlComposer.Select.t;
+};
+
+module Generator: (Config: Config) => {
+  let getById: (
+    Js.Json.t => 'a,
+    int,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(option('a));
+};

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -20,4 +20,10 @@ module Generator: (Config: Config) => {
     Js.Json.t,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option('a));
+  let get: (
+    SqlComposer.Select.t,
+    Js.Json.t => 'a,
+    Js.Json.t,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(array('a));
 };

--- a/src/FactorySql.re
+++ b/src/FactorySql.re
@@ -6,13 +6,11 @@ let removeHeadOfList = list =>
   };
 
 let mergeGroupBy = (base, userClauses) =>
-  SqlComposer.Select.(
-    userClauses
-    |> List.rev
-    |> removeHeadOfList
-    |> List.fold_left((acc, x) => group_by(x, acc), base)
-    |> (x => x.group_by)
-  );
+  userClauses
+  |> List.rev
+  |> removeHeadOfList
+  |> List.fold_left((acc, x) => SqlComposer.Select.group_by(x, acc), base)
+  |> (x => x.group_by);
 
 let mergeOrderBy = (baseClauses, userClauses) =>
   if (List.length(userClauses) == 0) {
@@ -27,13 +25,11 @@ let mergeOrderBy = (baseClauses, userClauses) =>
   };
 
 let mergeWhere = (base, userClauses) =>
-  SqlComposer.Select.(
-    userClauses
-    |> List.rev
-    |> removeHeadOfList
-    |> List.fold_left((acc, x) => where(x, acc), base)
-    |> (x => x.where)
-  );
+  userClauses
+  |> List.rev
+  |> removeHeadOfList
+  |> List.fold_left((acc, x) => SqlComposer.Select.where(x, acc), base)
+  |> (x => x.where);
 
 let mergeFields = (base, userClauses) =>
   userClauses


### PR DESCRIPTION
# SUPERSET OF THE FOLLOWING PR: https://github.com/scull7/bs-pimp-my-sql/pull/5

## Summary of the major changes in this PR:

- New: added `src/FactoryModel.re`; includes a functor to generate a basic Module with the getById, getByIdList, getOneBy, and get functions.
- New: added `src/FactoryModel.rei`.
- New: added `__tests__/TestFactoryModel.re`; includes test coverage for the getById, getByIdList, getOneBy, and get functions.

## Things of note:

- getByIdList is still broken because of a bug with the `mysql2` dependency.
