### PR TITLE
[DELIVERS #157208443] Model Factory Insert and Update

### DIFF
--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -71,7 +71,7 @@ describe("FactoryModel", () => {
          (
            switch (res) {
            | Some({id: 1, type_: "dog"}) => pass
-           | _ => fail("expected to get {id: 1, type_: 'dog'}")
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -109,7 +109,7 @@ describe("FactoryModel", () => {
          (
            switch (res) {
            | [||] => pass
-           | _ => pass
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -216,6 +216,36 @@ describe("FactoryModel", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
+  testPromise("update (returns 1 result)", () => {
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    let record = {type_: "hippopotamus"};
+    Model.update(decoder, encoder, record, 1, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some({id: 1, type_: "hippopotamus"}) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
+  testPromise("update (returns 1 result)", () => {
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    let record = {type_: "hippopotamus"};
+    Model.update(decoder, encoder, record, 99, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | None => pass
+           | Some(_) => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -262,6 +262,38 @@ describe("Query", () => {
          |> Js.Promise.resolve
        )
   );
+  testPromise("update (returns 1 result)", () => {
+    let decoder = json => json;
+    let record = {type_: "hamster"};
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.update(base, table, decoder, encoder, record, 1, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some(_) => pass
+           | None => fail("expected to get 1 result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
+  testPromise("update (fails and does not return anything)", () => {
+    let decoder = json => json;
+    let record = {type_: "goose"};
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.update(base, table, decoder, encoder, record, 99, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some(_) => fail("expected to get nothing back")
+           | None => pass
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -49,8 +49,6 @@ let createTestData = conn => {
 createTestData(conn);
 
 describe("Query", () => {
-  let encoder = x =>
-    [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;
   let decoder = json => {
     id: Json.Decode.field("id", Json.Decode.int, json),
     type_: Json.Decode.field("type_", Json.Decode.string, json),
@@ -198,7 +196,9 @@ describe("Query", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve(pass));
   });
-  testPromise("insertBatch (returns 2 results)", () =>
+  testPromise("insertBatch (returns 2 results)", () => {
+    let encoder = x =>
+      [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
@@ -217,9 +217,11 @@ describe("Query", () => {
            }
          )
          |> Js.Promise.resolve
-       )
-  );
-  testPromise("insertBatch (fails and throws unique constraint error)", () =>
+       );
+  });
+  testPromise("insertBatch (fails and throws unique constraint error)", () => {
+    let encoder = x =>
+      [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
@@ -238,9 +240,11 @@ describe("Query", () => {
            }
          )
          |> Js.Promise.resolve
-       )
-  );
-  testPromise("insertBatch (given empty array returns nothing)", () =>
+       );
+  });
+  testPromise("insertBatch (given empty array returns nothing)", () => {
+    let encoder = x =>
+      [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
@@ -259,8 +263,8 @@ describe("Query", () => {
            }
          )
          |> Js.Promise.resolve
-       )
-  );
+       );
+  });
   testPromise("update (returns 1 result)", () => {
     let record = {type_: "hamster"};
     let encoder = x =>

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -9,8 +9,6 @@ type animalExternal = {
 
 type animalInternal = {type_: string};
 
-external animalToJson : animalInternal => Js.Json.t = "%identity";
-
 let conn = MySql2.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
 
 let db = "pimpmysqltest";

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -173,8 +173,10 @@ describe("Query", () => {
   });
   testPromise("insert (returns 1 result)", () => {
     let decoder = json => json;
-    let record = [%raw "{\"type_\": \"pangolin\"}"];
-    Query.insert(base, table, decoder, animalToJson, record, conn)
+    let record = {type_: "pangolin"};
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.insert(base, table, decoder, encoder, record, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -188,7 +190,9 @@ describe("Query", () => {
   testPromise("insert (fails and throws error)", () => {
     let decoder = json => json;
     let record = {type_: "elephant"};
-    Query.insert(base, table, decoder, animalToJson, record, conn)
+    let encoder = x =>
+      [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.insert(base, table, decoder, encoder, record, conn)
     |> Js.Promise.then_((_) =>
          fail("expected to throw unique constraint error")
          |> Js.Promise.resolve

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -48,8 +48,9 @@ let createTestData = conn => {
 
 createTestData(conn);
 
-/* @TODO - improve tests for insertBatch by checking the actual content of the results */
 describe("Query", () => {
+  let encoder = x =>
+    [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;
   let decoder = json => {
     id: Json.Decode.field("id", Json.Decode.int, json),
     type_: Json.Decode.field("type_", Json.Decode.string, json),
@@ -60,7 +61,7 @@ describe("Query", () => {
          (
            switch (res) {
            | Some({id: 3, type_: "elephant"}) => pass
-           | None => fail("not an expected result")
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -115,7 +116,7 @@ describe("Query", () => {
          (
            switch (res) {
            | Some({id: 3, type_: "elephant"}) => pass
-           | None => fail("not an expected result")
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -201,7 +202,7 @@ describe("Query", () => {
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
-      ~encoder=animalToJson,
+      ~encoder,
       ~loader=animals => Js.Promise.resolve(animals),
       ~error=msg => msg,
       ~columns=[|"type_"|],
@@ -211,7 +212,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok([|_, _|]) => pass
+           | `Ok([|{type_: "catfish"}, {type_: "lumpsucker"}|]) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -222,7 +223,7 @@ describe("Query", () => {
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
-      ~encoder=animalToJson,
+      ~encoder,
       ~loader=animals => Js.Promise.resolve(animals),
       ~error=msg => msg,
       ~columns=[|"type_"|],
@@ -243,7 +244,7 @@ describe("Query", () => {
     Query.insertBatch(
       ~name="insertBatch test",
       ~table,
-      ~encoder=animalToJson,
+      ~encoder,
       ~loader=animals => Js.Promise.resolve(animals),
       ~error=msg => msg,
       ~columns=[|"type_"|],

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -48,7 +48,7 @@ let createTestData = conn => {
 
 createTestData(conn);
 
-/* @TODO - improve tests by checking the actual content of the results */
+/* @TODO - improve tests for insertBatch by checking the actual content of the results */
 describe("Query", () => {
   let decoder = json => {
     id: Json.Decode.field("id", Json.Decode.int, json),

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -41,4 +41,14 @@ module Generator = (Config: Config) => {
       record,
       conn,
     );
+  let update = (decoder, encoder, record, id, conn) =>
+    Query.update(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      decoder,
+      encoder,
+      record,
+      id,
+      conn,
+    );
 };

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -32,4 +32,13 @@ module Generator = (Config: Config) => {
       params,
       conn,
     );
+  let insert = (decoder, encoder, record, conn) =>
+    Query.insert(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      decoder,
+      encoder,
+      record,
+      conn,
+    );
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -26,4 +26,10 @@ module Generator: (Config: Config) => {
     Js.Json.t,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(array('a));
+  let insert: (
+    Js.Json.t => 'a,
+    Json.Encode.encoder('b),
+    'b,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(option('a));
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -32,4 +32,11 @@ module Generator: (Config: Config) => {
     'b,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option('a));
+  let update: (
+    Js.Json.t => 'a,
+    Json.Encode.encoder('b),
+    'b,
+    int,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(option('a));
 };

--- a/src/PimpMySql.re
+++ b/src/PimpMySql.re
@@ -1,3 +1,7 @@
 module Query = Query;
 
 module Params = Params;
+
+module Decode = Decode;
+
+module FactoryModel = FactoryModel;

--- a/src/PimpMySql.rei
+++ b/src/PimpMySql.rei
@@ -1,3 +1,7 @@
 module Query = Query;
 
 module Params = Params;
+
+module Decode = Decode;
+
+module FactoryModel = FactoryModel;

--- a/src/Query.re
+++ b/src/Query.re
@@ -74,3 +74,13 @@ let insertBatch =
          |> Js.Promise.resolve
        )
   };
+
+let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
+  let params =
+    Json.Encode.(
+      [|encoder @@ record, int @@ id|] |> jsonArray |> Params.positional
+    );
+  let sql = {j|UPDATE $table SET ? WHERE $table.`id` = ?|j};
+  Sql.Promise.mutate(conn, ~sql, ~params?, ())
+  |> Js.Promise.then_((_) => getById(baseQuery, table, decoder, id, conn));
+};

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -47,3 +47,13 @@ let insertBatch: (
   ~rows: array('a),
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t( [> `Error('c) | `Ok(array('b)) ]);
+
+let update: (
+  SqlComposer.Select.t,
+  string,
+  Js.Json.t => 'a,
+  Json.Encode.encoder('b),
+  'b,
+  int,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(option('a));


### PR DESCRIPTION
# SUPERSET OF THE FOLLOWING PR: https://github.com/scull7/bs-pimp-my-sql/pull/7

## Summary of the major changes in this PR:

- New: added insert to `src/FactoryModel.re`.
- New: added insert to `src/FactoryModel.rei`.
- New: added test coverage for insert in `__tests__/TestFactoryModel.re`.
- New: added update in `src/FactoryModel.re`.
- New: added update in `src/FactoryModel.rei`.
- New: added test coverage for update in `__tests__/TestFactoryModel.re`.
- New: added Decode and FactoryModel in `src/PimpMySql.re` and `src/PimpMySql.rei`.