### PR TITLE
[DELIVERS #157208443, #157235937] Soft Compound Delete

### DIFF
--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -256,6 +256,16 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
+  testPromise("update (does not return a result, throws bad field error)", () => {
+    let encoder = x =>
+      [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    let record = {type_: "hippopotamus"};
+    Model.update(decoder, encoder, record, 1, conn)
+    |> Js.Promise.then_((_) =>
+         Js.Promise.resolve @@ fail("not an expected result")
+       )
+    |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
+  });
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -216,6 +216,16 @@ describe("FactoryModel", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
+  testPromise("insert (does not return a result, throws bad field error)", () => {
+    let encoder = x =>
+      [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    let record = {type_: "flamingo"};
+    Model.insert(decoder, encoder, record, conn)
+    |> Js.Promise.then_((_) =>
+         Js.Promise.resolve @@ fail("not an expected result")
+       )
+    |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
+  });
   testPromise("update (returns 1 result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
@@ -231,7 +241,7 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("update (returns 1 result)", () => {
+  testPromise("update (does not return a result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -303,6 +303,16 @@ describe("Query", () => {
          |> Js.Promise.resolve
        );
   });
+  testPromise("update (fails and throws bad field error)", () => {
+    let record = {type_: "hippopotamus"};
+    let encoder = x =>
+      [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.update(base, table, decoder, encoder, record, 1, conn)
+    |> Js.Promise.then_((_) =>
+         Js.Promise.resolve @@ fail("not an expected result")
+       )
+    |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
+  });
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -47,9 +47,8 @@ let createTestData = conn => {
   Sql.mutate(conn, ~sql=seedTable, (_) => ());
 };
 
-createTestData(conn);
-
 describe("Query", () => {
+  createTestData(conn);
   let decoder = json =>
     Json.Decode.{
       id: field("id", int, json),

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -5,6 +5,7 @@ module Sql = SqlCommon.Make_sql(MySql2);
 type animalExternal = {
   id: int,
   type_: string,
+  deleted: int,
 };
 
 type animalInternal = {type_: string};
@@ -25,6 +26,8 @@ let createTable = {j|
   CREATE TABLE $table (
     id MEDIUMINT NOT NULL AUTO_INCREMENT,
     type_ VARCHAR(120) NOT NULL,
+    deleted TINYINT(1) NOT NULL DEFAULT 0,
+    deleted_timestamp TIMESTAMP NULL DEFAULT NULL,
     primary key (id),
     unique(type_)
   );
@@ -47,10 +50,12 @@ let createTestData = conn => {
 createTestData(conn);
 
 describe("Query", () => {
-  let decoder = json => {
-    id: Json.Decode.field("id", Json.Decode.int, json),
-    type_: Json.Decode.field("type_", Json.Decode.string, json),
-  };
+  let decoder = json =>
+    Json.Decode.{
+      id: field("id", int, json),
+      type_: field("type_", string, json),
+      deleted: field("deleted", int, json),
+    };
   testPromise("getById (returns 1 result)", () =>
     Query.getById(base, table, decoder, 3, conn)
     |> Js.Promise.then_(res =>
@@ -313,6 +318,30 @@ describe("Query", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
+  testPromise("softCompoundDelete (returns 1 result)", () =>
+    Query.softCompoundDelete(base, table, decoder, 2, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some({id: 2, type_: "cat", deleted: 1}) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
+  testPromise("softCompoundDelete (fails and does not return anything)", () =>
+    Query.softCompoundDelete(base, table, decoder, 99, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Some(_) => fail("not an expected result")
+           | None => pass
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -194,6 +194,16 @@ describe("Query", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve(pass));
   });
+  testPromise("insert (fails and throws bad field error)", () => {
+    let record = {type_: "flamingo"};
+    let encoder = x =>
+      [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
+    Query.insert(base, table, decoder, encoder, record, conn)
+    |> Js.Promise.then_((_) =>
+         Js.Promise.resolve @@ fail("not an expected result")
+       )
+    |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
+  });
   testPromise("insertBatch (returns 2 results)", () => {
     let encoder = x =>
       [|Json.Encode.string @@ x.type_|] |> Json.Encode.jsonArray;

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -51,4 +51,12 @@ module Generator = (Config: Config) => {
       id,
       conn,
     );
+  let softCompoundDelete = (decoder, id, conn) =>
+    Query.softCompoundDelete(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      decoder,
+      id,
+      conn,
+    );
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -39,4 +39,9 @@ module Generator: (Config: Config) => {
     int,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option('a));
+  let softCompoundDelete: (
+    Js.Json.t => 'a,
+    int,
+    SqlCommon.Make_sql(MySql2).connection
+  ) => Js.Promise.t(option('a));
 };

--- a/src/Query.re
+++ b/src/Query.re
@@ -84,3 +84,14 @@ let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
   Sql.Promise.mutate(conn, ~sql, ~params?, ())
   |> Js.Promise.then_((_) => getById(baseQuery, table, decoder, id, conn));
 };
+
+let softCompoundDelete = (baseQuery, table, decoder, id, conn) => {
+  let params = Json.Encode.([|int @@ id|] |> jsonArray |> Params.positional);
+  let sql = {j|
+    UPDATE $table
+    SET $table.`deleted` = 1, $table.`deleted_timestamp` = NOW()
+    WHERE $table.`id` = ?
+  |j};
+  Sql.Promise.mutate(conn, ~sql, ~params?, ())
+  |> Js.Promise.then_((_) => getById(baseQuery, table, decoder, id, conn));
+};

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -57,3 +57,11 @@ let update: (
   int,
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(option('a));
+
+let softCompoundDelete: (
+  SqlComposer.Select.t,
+  string,
+  Js.Json.t => 'a,
+  int,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(option('a));


### PR DESCRIPTION
## Summary of the major changes in this PR:

- Update: added additional test coverage in `__tests__/TestFactoryModel.re`.
- Update: added additional test coverage in `__tests__/TestQuery.re`.
- New: added softCompoundDelete in `src/Query.re`.
- New: added softCompoundDelete in `src/Query.rei`.
- New: added test coverage for softCompoundDelete in `__tests__/TestQuery.re`.
- New: added softCompoundDelete in `src/FactoryModel.re`.
- New: added softCompoundDelete in `src/FactoryModel.rei`.
- New: added test coverage for softCompoundDelete in `__tests__/TestFactoryModel.re`.