### PR TITLE
[DELIVERS #157235937, #157208443] Updated the Readme and the update/softCompoundDeleteById functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ client.
 
 Inside of a BuckleScript project:
 ```shell
-yarn add bs-sql-common bs-mysql2 bs-pimp-my-sql
+yarn add @glennsl/bs-json bs-sql-composer bs-sql-common bs-mysql2 bs-pimp-my-sql
 ```
 
 Then add `@glennsl/bs-json`, `bs-sql-composer`, `bs-sql-common`, `bs-mysql2`, and

--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ Inside of a BuckleScript project:
 ```shell
 yarn add bs-sql-common bs-mysql2 bs-pimp-my-sql
 ```
-Then add `bs-sql-common`, `bs-mysql2`, and `bs-pimp-my-sql` to your `bs-dependencies`
-in `bsconfig.json`:
+
+Then add `@glennsl/bs-json`, `bs-sql-composer`, `bs-sql-common`, `bs-mysql2`, and
+`bs-pimp-my-sql` to your `bs-dependencies` in `bsconfig.json`:
 
 ```json
 {
   "bs-dependencies": [
+    "@glennsl/bs-json",
     "bs-mysql2",
     "bs-pimp-my-sql",
-    "bs-sql-common"
+    "bs-sql-common",
+    "bs-sql-composer"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Inside of a BuckleScript project:
 yarn add @glennsl/bs-json bs-sql-composer bs-sql-common bs-mysql2 bs-pimp-my-sql
 ```
 
-Then add `@glennsl/bs-json`, `bs-sql-composer`, `bs-sql-common`, `bs-mysql2`, and
-`bs-pimp-my-sql` to your `bs-dependencies` in `bsconfig.json`:
+Then add `@glennsl/bs-json`, `bs-mysql2`, `bs-pimp-my-sql`, `bs-result`, `bs-sql-common`,
+and `bs-sql-composer` to your `bs-dependencies` in `bsconfig.json`:
 
 ```json
 {
@@ -27,6 +27,7 @@ Then add `@glennsl/bs-json`, `bs-sql-composer`, `bs-sql-common`, `bs-mysql2`, an
     "@glennsl/bs-json",
     "bs-mysql2",
     "bs-pimp-my-sql",
+    "bs-result",
     "bs-sql-common",
     "bs-sql-composer"
   ]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ client.
 
 Inside of a BuckleScript project:
 ```shell
-yarn add bs-pimp-my-sql
+yarn add bs-sql-common bs-mysql2 bs-pimp-my-sql
+```
+Then add `bs-sql-common`, `bs-mysql2`, and `bs-pimp-my-sql` to your `bs-dependencies`
+in `bsconfig.json`:
+
+```json
+{
+  "bs-dependencies": [
+    "bs-mysql2",
+    "bs-pimp-my-sql",
+    "bs-sql-common"
+  ]
+}
 ```
 
 ## How do I use it?
@@ -40,7 +52,7 @@ module Config = {
     );
 };
 
-module Model = FactoryModel.Generator(Config);
+module Model = PimpMySql.FactoryModel.Generator(Config);
 
 let decoder = json =>
   Json.Decode.{

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -255,8 +255,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Error(_) => pass
-           | Result.Ok(_) => fail("not an expected result")
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -289,8 +289,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Error(_) => pass
-           | Result.Ok(_) => fail("not an expected result")
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -14,7 +14,7 @@ module Sql = SqlCommon.Make_sql(MySql2);
 
 let conn = Sql.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
 
-let db = "pimpmysqltest";
+let db = "pimpmysqlfactorymodel";
 
 let table = "animal";
 

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -240,7 +240,7 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(Some({id: 1, type_: "hippopotamus"})) => pass
+           | Result.Ok(Some({id: 1, type_: "hippopotamus"})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -255,8 +255,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `NotFound => pass
-           | `Ok(_) => fail("not an expected result")
+           | Result.Error(_) => pass
+           | Result.Ok(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -277,7 +277,7 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
+           | Result.Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -289,8 +289,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `NotFound => pass
-           | `Ok(_) => fail("not an expected result")
+           | Result.Error(_) => pass
+           | Result.Ok(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -277,7 +277,7 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some({id: 2, type_: "cat", deleted: 1}) => pass
+           | `Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -289,8 +289,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | None => pass
-           | Some(_) => fail("not an expected result")
+           | `NotFound => pass
+           | `Ok(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -12,7 +12,7 @@ type animalInternal = {type_: string};
 /* Database Creation and Connection */
 module Sql = SqlCommon.Make_sql(MySql2);
 
-let conn = MySql2.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
+let conn = Sql.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
 
 let db = "pimpmysqltest";
 
@@ -55,10 +55,10 @@ module Config = {
   let base =
     SqlComposer.Select.(
       select
-      |> field("animal.id")
-      |> field("animal.type_")
-      |> field("animal.deleted")
-      |> order_by(`Desc("animal.id"))
+      |> field({j|$table.`id`|j})
+      |> field({j|$table.`type_`|j})
+      |> field({j|$table.`deleted`|j})
+      |> order_by(`Desc({j|$table.`id`|j}))
     );
 };
 

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -272,8 +272,8 @@ describe("FactoryModel", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("softCompoundDelete (returns 1 result)", () =>
-    Model.softCompoundDelete(decoder, 2, conn)
+  testPromise("softCompoundDeleteById (returns 1 result)", () =>
+    Model.softCompoundDeleteById(decoder, 2, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -284,8 +284,8 @@ describe("FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("softCompoundDelete (does not return a result)", () =>
-    Model.softCompoundDelete(decoder, 99, conn)
+  testPromise("softCompoundDeleteById (does not return a result)", () =>
+    Model.softCompoundDeleteById(decoder, 99, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestFactoryModel.re
+++ b/__tests__/TestFactoryModel.re
@@ -240,7 +240,7 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some({id: 1, type_: "hippopotamus"}) => pass
+           | `Ok(Some({id: 1, type_: "hippopotamus"})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -255,8 +255,8 @@ describe("FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | None => pass
-           | Some(_) => fail("not an expected result")
+           | `NotFound => pass
+           | `Ok(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -317,8 +317,8 @@ describe("Query", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("softCompoundDelete (returns 1 result)", () =>
-    Query.softCompoundDelete(base, table, decoder, 2, conn)
+  testPromise("softCompoundDeleteById (returns 1 result)", () =>
+    Query.softCompoundDeleteById(base, table, decoder, 2, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -329,8 +329,9 @@ describe("Query", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("softCompoundDelete (fails and does not return anything)", () =>
-    Query.softCompoundDelete(base, table, decoder, 99, conn)
+  testPromise(
+    "softCompoundDeleteById (fails and does not return anything)", () =>
+    Query.softCompoundDeleteById(base, table, decoder, 99, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -285,7 +285,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some({id: 1, type_: "hamster"}) => pass
+           | `Ok(Some({id: 1, type_: "hamster"})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -300,8 +300,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some(_) => fail("not an expected result")
-           | None => pass
+           | `Ok(_) => fail("not an expected result")
+           | `NotFound => pass
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -224,7 +224,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok([|{type_: "catfish"}, {type_: "lumpsucker"}|]) => pass
+           | Result.Ok([|{type_: "catfish"}, {type_: "lumpsucker"}|]) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -247,8 +247,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Error(_) => pass
-           | `Ok(_) => fail("not an expected result")
+           | Result.Error(_) => pass
+           | Result.Ok(_) => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -270,7 +270,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok([||]) => pass
+           | Result.Ok([||]) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -285,7 +285,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(Some({id: 1, type_: "hamster"})) => pass
+           | Result.Ok(Some({id: 1, type_: "hamster"})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -300,8 +300,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(_) => fail("not an expected result")
-           | `NotFound => pass
+           | Result.Ok(_) => fail("not an expected result")
+           | Result.Error(_) => pass
            }
          )
          |> Js.Promise.resolve
@@ -322,7 +322,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
+           | Result.Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -334,8 +334,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | `Ok(_) => fail("not an expected result")
-           | `NotFound => pass
+           | Result.Ok(_) => fail("not an expected result")
+           | Result.Error(_) => pass
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -300,8 +300,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Ok(_) => fail("not an expected result")
-           | Result.Error(_) => pass
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve
@@ -334,8 +334,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Ok(_) => fail("not an expected result")
-           | Result.Error(_) => pass
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
            }
          )
          |> Js.Promise.resolve

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -12,7 +12,7 @@ type animalInternal = {type_: string};
 
 let conn = MySql2.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
 
-let db = "pimpmysqltest";
+let db = "pimpmysqlquery";
 
 let table = "animals";
 

--- a/__tests__/TestQuery.re
+++ b/__tests__/TestQuery.re
@@ -322,7 +322,7 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some({id: 2, type_: "cat", deleted: 1}) => pass
+           | `Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
          )
@@ -334,8 +334,8 @@ describe("Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Some(_) => fail("not an expected result")
-           | None => pass
+           | `Ok(_) => fail("not an expected result")
+           | `NotFound => pass
            }
          )
          |> Js.Promise.resolve

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -20,6 +20,7 @@
   "bs-dependencies": [
     "@glennsl/bs-json",
     "bs-mysql2",
+    "bs-result",
     "bs-sql-common",
     "bs-sql-composer"
   ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@glennsl/bs-json": "^1.2.0",
     "bs-mysql2": "^3.1.0",
+    "bs-result": "^1.0.0",
     "bs-sql-common": "^1.0.1",
     "bs-sql-composer": "^1.0.0"
   },

--- a/src/FactoryModel.re
+++ b/src/FactoryModel.re
@@ -51,8 +51,8 @@ module Generator = (Config: Config) => {
       id,
       conn,
     );
-  let softCompoundDelete = (decoder, id, conn) =>
-    Query.softCompoundDelete(
+  let softCompoundDeleteById = (decoder, id, conn) =>
+    Query.softCompoundDeleteById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       decoder,

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -38,10 +38,10 @@ module Generator: (Config: Config) => {
     'b,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
+  ) => Js.Promise.t(Result.result(string, option('a)));
   let softCompoundDelete: (
     Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
+  ) => Js.Promise.t(Result.result(string, option('a)));
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -39,7 +39,7 @@ module Generator: (Config: Config) => {
     int,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(Result.result(exn, option('a)));
-  let softCompoundDelete: (
+  let softCompoundDeleteById: (
     Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -38,10 +38,10 @@ module Generator: (Config: Config) => {
     'b,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(Result.result(string, option('a)));
+  ) => Js.Promise.t(Result.result(exn, option('a)));
   let softCompoundDelete: (
     Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(Result.result(string, option('a)));
+  ) => Js.Promise.t(Result.result(exn, option('a)));
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -43,5 +43,5 @@ module Generator: (Config: Config) => {
     Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(option('a));
+  ) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
 };

--- a/src/FactoryModel.rei
+++ b/src/FactoryModel.rei
@@ -38,7 +38,7 @@ module Generator: (Config: Config) => {
     'b,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(option('a));
+  ) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
   let softCompoundDelete: (
     Js.Json.t => 'a,
     int,

--- a/src/PimpMySql.re
+++ b/src/PimpMySql.re
@@ -5,3 +5,5 @@ module Params = Params;
 module Decode = Decode;
 
 module FactoryModel = FactoryModel;
+
+module Error = PimpMySql_Error;

--- a/src/PimpMySql_Error.re
+++ b/src/PimpMySql_Error.re
@@ -1,0 +1,1 @@
+exception NotFound(string);

--- a/src/Query.re
+++ b/src/Query.re
@@ -82,7 +82,14 @@ let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
     );
   let sql = {j|UPDATE $table SET ? WHERE $table.`id` = ?|j};
   Sql.Promise.mutate(conn, ~sql, ~params?, ())
-  |> Js.Promise.then_((_) => getById(baseQuery, table, decoder, id, conn));
+  |> Js.Promise.then_(((success, _)) =>
+       if (success == 1) {
+         getById(baseQuery, table, decoder, id, conn)
+         |> Js.Promise.then_(res => Js.Promise.resolve(`Ok(res)));
+       } else {
+         Js.Promise.resolve(`NotFound);
+       }
+     );
 };
 
 let softCompoundDelete = (baseQuery, table, decoder, id, conn) => {

--- a/src/Query.re
+++ b/src/Query.re
@@ -66,11 +66,11 @@ let insertBatch =
       ~rows=Belt_Array.map(rows, encoder),
     )
     |> Js.Promise.then_((_) => loader(rows))
-    |> Js.Promise.then_(result => Result.Ok(result) |> Js.Promise.resolve)
+    |> Js.Promise.then_(result => Result.pure(result) |> Js.Promise.resolve)
     |> Js.Promise.catch(e =>
          {j|ERROR: $name - $e|j}
          |> error
-         |> (x => Result.Error(x))
+         |> (x => Result.error(x))
          |> Js.Promise.resolve
        )
   };
@@ -85,10 +85,10 @@ let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
   |> Js.Promise.then_(((success, _)) =>
        if (success == 1) {
          getById(baseQuery, table, decoder, id, conn)
-         |> Js.Promise.then_(res => Js.Promise.resolve(Result.Ok(res)));
+         |> Js.Promise.then_(res => Js.Promise.resolve(Result.pure(res)));
        } else {
          PimpMySql_Error.NotFound("ERROR: update failed")
-         |> (x => Result.Error(x))
+         |> (x => Result.error(x))
          |> Js.Promise.resolve;
        }
      );
@@ -105,10 +105,10 @@ let softCompoundDeleteById = (baseQuery, table, decoder, id, conn) => {
   |> Js.Promise.then_(((success, _)) =>
        if (success == 1) {
          getById(baseQuery, table, decoder, id, conn)
-         |> Js.Promise.then_(res => Js.Promise.resolve(Result.Ok(res)));
+         |> Js.Promise.then_(res => Js.Promise.resolve(Result.pure(res)));
        } else {
          PimpMySql_Error.NotFound("ERROR: softCompoundDelete failed")
-         |> (x => Result.Error(x))
+         |> (x => Result.error(x))
          |> Js.Promise.resolve;
        }
      );

--- a/src/Query.re
+++ b/src/Query.re
@@ -56,7 +56,7 @@ let insert = (baseQuery, table, decoder, encoder, record, conn) => {
 let insertBatch =
     (~name, ~table, ~encoder, ~loader, ~error, ~columns, ~rows, conn) =>
   switch (rows) {
-  | [||] => Result.Ok([||]) |> Js.Promise.resolve
+  | [||] => Result.pure([||]) |> Js.Promise.resolve
   | _ =>
     Sql.Promise.mutate_batch(
       conn,

--- a/src/Query.re
+++ b/src/Query.re
@@ -87,7 +87,9 @@ let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
          getById(baseQuery, table, decoder, id, conn)
          |> Js.Promise.then_(res => Js.Promise.resolve(Result.Ok(res)));
        } else {
-         Result.Error("ERROR: update failed") |> Js.Promise.resolve;
+         PimpMySql_Error.NotFound("ERROR: update failed")
+         |> (x => Result.Error(x))
+         |> Js.Promise.resolve;
        }
      );
 };
@@ -105,7 +107,8 @@ let softCompoundDelete = (baseQuery, table, decoder, id, conn) => {
          getById(baseQuery, table, decoder, id, conn)
          |> Js.Promise.then_(res => Js.Promise.resolve(Result.Ok(res)));
        } else {
-         Result.Error("ERROR: softCompoundDelete failed")
+         PimpMySql_Error.NotFound("ERROR: softCompoundDelete failed")
+         |> (x => Result.Error(x))
          |> Js.Promise.resolve;
        }
      );

--- a/src/Query.re
+++ b/src/Query.re
@@ -94,7 +94,7 @@ let update = (baseQuery, table, decoder, encoder, record, id, conn) => {
      );
 };
 
-let softCompoundDelete = (baseQuery, table, decoder, id, conn) => {
+let softCompoundDeleteById = (baseQuery, table, decoder, id, conn) => {
   let params = Json.Encode.([|int @@ id|] |> jsonArray |> Params.positional);
   let sql = {j|
     UPDATE $table

--- a/src/Query.re
+++ b/src/Query.re
@@ -93,5 +93,12 @@ let softCompoundDelete = (baseQuery, table, decoder, id, conn) => {
     WHERE $table.`id` = ?
   |j};
   Sql.Promise.mutate(conn, ~sql, ~params?, ())
-  |> Js.Promise.then_((_) => getById(baseQuery, table, decoder, id, conn));
+  |> Js.Promise.then_(((success, _)) =>
+       if (success == 1) {
+         getById(baseQuery, table, decoder, id, conn)
+         |> Js.Promise.then_(res => Js.Promise.resolve(`Ok(res)));
+       } else {
+         Js.Promise.resolve(`NotFound);
+       }
+     );
 };

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -56,7 +56,7 @@ let update: (
   'b,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t(option('a));
+) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
 
 let softCompoundDelete: (
   SqlComposer.Select.t,

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -56,7 +56,7 @@ let update: (
   'b,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t(Result.result(string, option('a)));
+) => Js.Promise.t(Result.result(exn, option('a)));
 
 let softCompoundDelete: (
   SqlComposer.Select.t,
@@ -64,4 +64,4 @@ let softCompoundDelete: (
   Js.Json.t => 'a,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t(Result.result(string, option('a)));
+) => Js.Promise.t(Result.result(exn, option('a)));

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -46,7 +46,7 @@ let insertBatch: (
   ~columns: array(string),
   ~rows: array('a),
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t( [> `Error('c) | `Ok(array('b)) ]);
+) => Js.Promise.t([> `Error('c) | `Ok(array('b)) ]);
 
 let update: (
   SqlComposer.Select.t,
@@ -64,4 +64,4 @@ let softCompoundDelete: (
   Js.Json.t => 'a,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t(option('a));
+) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -58,7 +58,7 @@ let update: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
 
-let softCompoundDelete: (
+let softCompoundDeleteById: (
   SqlComposer.Select.t,
   string,
   Js.Json.t => 'a,

--- a/src/Query.rei
+++ b/src/Query.rei
@@ -46,7 +46,7 @@ let insertBatch: (
   ~columns: array(string),
   ~rows: array('a),
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t([> `Error('c) | `Ok(array('b)) ]);
+) => Js.Promise.t(Result.result('c, array('b)));
 
 let update: (
   SqlComposer.Select.t,
@@ -56,7 +56,7 @@ let update: (
   'b,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
+) => Js.Promise.t(Result.result(string, option('a)));
 
 let softCompoundDelete: (
   SqlComposer.Select.t,
@@ -64,4 +64,4 @@ let softCompoundDelete: (
   Js.Json.t => 'a,
   int,
   SqlCommon.Make_sql(MySql2).connection
-) => Js.Promise.t([> `NotFound | `Ok(option('a)) ]);
+) => Js.Promise.t(Result.result(string, option('a)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,6 +430,10 @@ bs-mysql2@^3.1.0:
   dependencies:
     mysql2 "^1.5.1"
 
+bs-result@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/bs-result/-/bs-result-1.0.0.tgz#ac163e1384e1529d5f68e1caee16c65ebeb70a98"
+
 bs-sql-common@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bs-sql-common/-/bs-sql-common-1.0.1.tgz#03cee3681bf9e83117f51bee36f1d9c74f5acf69"


### PR DESCRIPTION
## Summary of the major changes in this PR:

- Update: updated `README.md`.
- Update: refactored `__tests__/TestFactoryModel.re`.
- Update: renamed softCompoundDelete to softCompoundDeleteById.
- Update: made changes to the return type of softCompoundDeleteId in `src/Query.re`.
- Update: updated the return type of update in `src/Query.re`.
- New: added bs-result to `package.json`.
- New: added bs-result to `bsconfig.json`.
- Update: updated `yarn.lock` file.
- Update: refactored Query and FactoryModel to use the result type in `bs-result`.
- New: added `src/PimpMySql_Error.re`.
- Update: refactored update and softCompoundDeleteById to return an exception when the supplied id cannot be found.