### PR TITLE
Refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Everything not checked...
   - [ ] INSERT
     - [x] _(insert)_ basic wrapper
   - [ ] UPDATE
-    - [x] _(updateById)_ Basic wrapper
+    - [x] _(updateOneById)_ Basic wrapper
     - [ ] _(updateWhereParams)_ with the `ObjectHash` interface
     - [ ] _(increment)_ increment an integer column - must fit the `Counter` interface
   - [ ] DELETE
@@ -114,7 +114,7 @@ Everything not checked...
   - [ ] Archive
     - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
     - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
-    - [x] _(archiveCompoundById)_ Soft Compound DELETE a row - must fit the `ArchiveCompound` interface
+    - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row - must fit the `ArchiveCompound` interface
   - [ ] SELECT
     - [ ] Transforms
       - [ ] JSON column parse
@@ -135,7 +135,7 @@ Everything not checked...
       - [ ] Pre-Create intercept
       - [ ] Post-Create intercept
     - [ ] UPDATE
-      - [x] _(updateById)_
+      - [x] _(updateOneById)_
       - [ ] Pre-Update intercept
       - [ ] Post-Update intercept
       - [ ] _(increment)_ increment an integer column - must fit the `Counter` interface
@@ -145,7 +145,7 @@ Everything not checked...
     - [ ] Archive
       - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
       - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
-      - [x] _(archiveCompoundById)_ Soft Compound DELETE a row - must fit the `ArchiveCompound` interface
+      - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row - must fit the `ArchiveCompound` interface
     - [ ] SELECT
       - [ ] Transforms - _(Dependent upon Query Interface implementation)_
       - [x] _(get)_ using the Compositional SQL DSL

--- a/README.md
+++ b/README.md
@@ -55,8 +55,21 @@ let conn = Sql.connect(~host="127.0.0.1", ~port=3306, ~user="root", ~database="e
 
 let table = "animal";
 
+type animal = {
+  id: int,
+  type_: string,
+  deleted: int,
+};
+
 module Config = {
+  let t = animal;
   let table = table;
+  let decoder = json =>
+    Json.Decode.{
+      id: field("id", int, json),
+      type_: field("type_", string, json),
+      deleted: field("deleted", int, json),
+    };
   let base =
     SqlComposer.Select.(
       select
@@ -69,14 +82,7 @@ module Config = {
 
 module Model = PimpMySql.FactoryModel.Generator(Config);
 
-let decoder = json =>
-  Json.Decode.{
-    id: field("id", int, json),
-    type_: field("type_", string, json),
-    deleted: field("deleted", int, json),
-  };
-
-Model.getById(decoder, 1, conn)
+Model.getById(1, conn)
 |> Js.Promise.then_(res =>
      (
        switch (res) {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ type animal = {
 
 module Config = {
   let t = animal;
+  let connection = conn;
   let table = table;
   let decoder = json =>
     Json.Decode.{
@@ -82,7 +83,7 @@ module Config = {
 
 module Model = PimpMySql.FactoryModel.Generator(Config);
 
-Model.getById(1, conn)
+Model.getById(1)
 |> Js.Promise.then_(res =>
      (
        switch (res) {

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ Everything not checked...
   - [x] _(raw)_ Raw SQL query
   - [ ] _(rawInsert)_ Raw SQL insert
   - [ ] _(rawUpdate)_ Raw SQL update
-  - [ ] INSERT
-    - [x] _(insert)_ basic wrapper
+  - [x] INSERT
+    - [x] _(insertOne)_ basic wrapper
+    - [x] _(insertBatch)_ basic wrapper
   - [ ] UPDATE
     - [x] _(updateOneById)_ Basic wrapper
     - [ ] _(updateWhereParams)_ with the `ObjectHash` interface
@@ -131,7 +132,8 @@ Everything not checked...
   - [x] Model Creation DSL
   - [x] Query interface
     - [ ] INSERT
-      - [x] _(insert)_
+      - [x] _(insertOne)_
+      - [ ] _(insertBatch)_
       - [ ] Pre-Create intercept
       - [ ] Post-Create intercept
     - [ ] UPDATE

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -198,11 +198,11 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("insert (returns 1 result)", () => {
+  testPromise("insertOne (returns 1 result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "monkey"};
-    Model.insert(encoder, record, conn)
+    Model.insertOne(encoder, record, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -213,21 +213,22 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("insert (fails and throws unique constraint error)", () => {
+  testPromise("insertOne (fails and throws unique constraint error)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "dog"};
-    Model.insert(encoder, record, conn)
+    Model.insertOne(encoder, record, conn)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("insert (does not return a result, throws bad field error)", () => {
+  testPromise(
+    "insertOne (does not return a result, throws bad field error)", () => {
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "flamingo"};
-    Model.insert(encoder, record, conn)
+    Model.insertOne(encoder, record, conn)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -29,7 +29,7 @@ let createTable = {j|
     id MEDIUMINT NOT NULL AUTO_INCREMENT,
     type_ VARCHAR(120) NOT NULL,
     deleted TINYINT(1) NOT NULL DEFAULT 0,
-    deleted_timestamp TIMESTAMP NULL DEFAULT NULL,
+    deleted_timestamp int(10) UNSIGNED NOT NULL DEFAULT 0,
     primary key (id),
     unique(type_)
   );

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -233,11 +233,11 @@ describe("PimpMySql_FactoryModel", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("updateById (returns 1 result)", () => {
+  testPromise("updateOneById (returns 1 result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateById(encoder, record, 1, conn)
+    Model.updateOneById(encoder, record, 1, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -248,11 +248,11 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("updateById (does not return a result)", () => {
+  testPromise("updateOneById (does not return a result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateById(encoder, record, 99, conn)
+    Model.updateOneById(encoder, record, 99, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -264,18 +264,18 @@ describe("PimpMySql_FactoryModel", () => {
        );
   });
   testPromise(
-    "updateById (does not return a result, throws bad field error)", () => {
+    "updateOneById (does not return a result, throws bad field error)", () => {
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateById(encoder, record, 1, conn)
+    Model.updateOneById(encoder, record, 1, conn)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("archiveCompoundById (returns 1 result)", () =>
-    Model.archiveCompoundById(2, conn)
+  testPromise("archiveCompoundOneById (returns 1 result)", () =>
+    Model.archiveCompoundOneById(2, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -286,8 +286,8 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("archiveCompoundById (does not return a result)", () =>
-    Model.archiveCompoundById(99, conn)
+  testPromise("archiveCompoundOneById (does not return a result)", () =>
+    Model.archiveCompoundOneById(99, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -52,6 +52,7 @@ let createTestData = conn => {
 /* Model Factory */
 module Config = {
   type t = animal;
+  let connection = conn;
   let table = table;
   let decoder = json =>
     Json.Decode.{
@@ -75,7 +76,7 @@ module Model = PimpMySql_FactoryModel.Generator(Config);
 describe("PimpMySql_FactoryModel", () => {
   createTestData(conn);
   testPromise("getOneById (returns a result)", () =>
-    Model.getOneById(1, conn)
+    Model.getOneById(1)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -87,7 +88,7 @@ describe("PimpMySql_FactoryModel", () => {
        )
   );
   testPromise("getOneById (does not return a result)", () =>
-    Model.getOneById(5, conn)
+    Model.getOneById(5)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -99,7 +100,7 @@ describe("PimpMySql_FactoryModel", () => {
        )
   );
   testPromise("getByIdList (returns 2 results)", () =>
-    Model.getByIdList([1, 2], conn)
+    Model.getByIdList([1, 2])
     |> Js.Promise.then_(res =>
          (
            /*@TODO: there is a bug with mysql2, once fixed add
@@ -113,7 +114,7 @@ describe("PimpMySql_FactoryModel", () => {
        )
   );
   testPromise("getByIdList (does not return any results)", () =>
-    Model.getByIdList([4, 5], conn)
+    Model.getByIdList([4, 5])
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -132,7 +133,7 @@ describe("PimpMySql_FactoryModel", () => {
         |> where({j|AND $table.`type_` = ?|j})
       );
     let params = Json.Encode.([|int(1), string("dog")|] |> jsonArray);
-    Model.getOneBy(userClauses, params, conn)
+    Model.getOneBy(userClauses, params)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -151,7 +152,7 @@ describe("PimpMySql_FactoryModel", () => {
         |> where({j|AND $table.`type_` = ?|j})
       );
     let params = Json.Encode.([|int(1), string("cat")|] |> jsonArray);
-    Model.getOneBy(userClauses, params, conn)
+    Model.getOneBy(userClauses, params)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -170,7 +171,7 @@ describe("PimpMySql_FactoryModel", () => {
         |> where({j|AND $table.`type_` LIKE CONCAT("%", ?, "%")|j})
       );
     let params = Json.Encode.([|int(1), string("a")|] |> jsonArray);
-    Model.get(userClauses, params, conn)
+    Model.get(userClauses, params)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -187,7 +188,7 @@ describe("PimpMySql_FactoryModel", () => {
         select |> where({j|AND $table.`type_` LIKE CONCAT(?, "%")|j})
       );
     let params = Json.Encode.([|string("z")|] |> jsonArray);
-    Model.get(userClauses, params, conn)
+    Model.get(userClauses, params)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -202,7 +203,7 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "monkey"};
-    Model.insertOne(encoder, record, conn)
+    Model.insertOne(encoder, record)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -217,7 +218,7 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "dog"};
-    Model.insertOne(encoder, record, conn)
+    Model.insertOne(encoder, record)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
@@ -228,7 +229,7 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "flamingo"};
-    Model.insertOne(encoder, record, conn)
+    Model.insertOne(encoder, record)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
@@ -238,7 +239,7 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateOneById(encoder, record, 1, conn)
+    Model.updateOneById(encoder, record, 1)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -253,7 +254,7 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateOneById(encoder, record, 99, conn)
+    Model.updateOneById(encoder, record, 99)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -269,14 +270,14 @@ describe("PimpMySql_FactoryModel", () => {
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
     let record = {type_: "hippopotamus"};
-    Model.updateOneById(encoder, record, 1, conn)
+    Model.updateOneById(encoder, record, 1)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
   testPromise("archiveCompoundOneById (returns 1 result)", () =>
-    Model.archiveCompoundOneById(2, conn)
+    Model.archiveCompoundOneById(2)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -288,7 +289,7 @@ describe("PimpMySql_FactoryModel", () => {
        )
   );
   testPromise("archiveCompoundOneById (does not return a result)", () =>
-    Model.archiveCompoundOneById(99, conn)
+    Model.archiveCompoundOneById(99)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -1,7 +1,6 @@
 open Jest;
 
-module Sql = SqlCommon.Make_sql(MySql2);
-
+/* Types */
 type animalExternal = {
   id: int,
   type_: string,
@@ -10,7 +9,10 @@ type animalExternal = {
 
 type animalInternal = {type_: string};
 
-let conn = MySql2.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
+/* Database Creation and Connection */
+module Sql = SqlCommon.Make_sql(MySql2);
+
+let conn = Sql.connect(~host="127.0.0.1", ~port=3306, ~user="root", ());
 
 let db = "pimpmysqlquery";
 
@@ -47,6 +49,7 @@ let createTestData = conn => {
   Sql.mutate(conn, ~sql=seedTable, (_) => ());
 };
 
+/* Model Factory */
 describe("PimpMySql_Query", () => {
   createTestData(conn);
   let decoder = json =>

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -280,11 +280,19 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("updateById (returns 1 result)", () => {
+  testPromise("updateOneById (returns 1 result)", () => {
     let record = {type_: "hamster"};
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.updateById(base, table, decoder, encoder, record, 1, conn)
+    PimpMySql_Query.updateOneById(
+      base,
+      table,
+      decoder,
+      encoder,
+      record,
+      1,
+      conn,
+    )
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -295,11 +303,19 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("updateById (fails and does not return anything)", () => {
+  testPromise("updateOneById (fails and does not return anything)", () => {
     let record = {type_: "goose"};
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.updateById(base, table, decoder, encoder, record, 9, conn)
+    PimpMySql_Query.updateOneById(
+      base,
+      table,
+      decoder,
+      encoder,
+      record,
+      9,
+      conn,
+    )
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -310,18 +326,26 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("updateById (fails and throws bad field error)", () => {
+  testPromise("updateOneById (fails and throws bad field error)", () => {
     let record = {type_: "hippopotamus"};
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.updateById(base, table, decoder, encoder, record, 1, conn)
+    PimpMySql_Query.updateOneById(
+      base,
+      table,
+      decoder,
+      encoder,
+      record,
+      1,
+      conn,
+    )
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
-  testPromise("archiveCompoundById (returns 1 result)", () =>
-    PimpMySql_Query.archiveCompoundById(base, table, decoder, 2, conn)
+  testPromise("archiveCompoundOneById (returns 1 result)", () =>
+    PimpMySql_Query.archiveCompoundOneById(base, table, decoder, 2, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -332,8 +356,9 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("archiveCompoundById (fails and does not return anything)", () =>
-    PimpMySql_Query.archiveCompoundById(base, table, decoder, 99, conn)
+  testPromise(
+    "archiveCompoundOneById (fails and does not return anything)", () =>
+    PimpMySql_Query.archiveCompoundOneById(base, table, decoder, 99, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -29,7 +29,7 @@ let createTable = {j|
     id MEDIUMINT NOT NULL AUTO_INCREMENT,
     type_ VARCHAR(120) NOT NULL,
     deleted TINYINT(1) NOT NULL DEFAULT 0,
-    deleted_timestamp TIMESTAMP NULL DEFAULT NULL,
+    deleted_timestamp int(10) UNSIGNED NOT NULL DEFAULT 0,
     primary key (id),
     unique(type_)
   );

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -176,11 +176,11 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("insert (returns 1 result)", () => {
+  testPromise("insertOne (returns 1 result)", () => {
     let record = {type_: "pangolin"};
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.insert(base, table, decoder, encoder, record, conn)
+    PimpMySql_Query.insertOne(base, table, decoder, encoder, record, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -191,21 +191,21 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
-  testPromise("insert (fails and throws unique constraint error)", () => {
+  testPromise("insertOne (fails and throws unique constraint error)", () => {
     let record = {type_: "elephant"};
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.insert(base, table, decoder, encoder, record, conn)
+    PimpMySql_Query.insertOne(base, table, decoder, encoder, record, conn)
     |> Js.Promise.then_((_) =>
          fail("not an expected result") |> Js.Promise.resolve
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve(pass));
   });
-  testPromise("insert (fails and throws bad field error)", () => {
+  testPromise("insertOne (fails and throws bad field error)", () => {
     let record = {type_: "flamingo"};
     let encoder = x =>
       [("bad_column", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;
-    PimpMySql_Query.insert(base, table, decoder, encoder, record, conn)
+    PimpMySql_Query.insertOne(base, table, decoder, encoder, record, conn)
     |> Js.Promise.then_((_) =>
          Js.Promise.resolve @@ fail("not an expected result")
        )

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -110,11 +110,9 @@ describe("PimpMySql_Query", () => {
   );
   testPromise("getOneBy (returns 1 result)", () => {
     let sql =
-      SqlComposer.Select.(
-        base |> where({j|AND $table.`type_` = ?|j}) |> to_sql
-      );
+      SqlComposer.Select.(base |> where({j|AND $table.`type_` = ?|j}));
     let params = Json.Encode.([|string("elephant")|] |> jsonArray);
-    PimpMySql_Query.getOneBy(decoder, sql, params, conn)
+    PimpMySql_Query.getOneBy(sql, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -127,11 +125,9 @@ describe("PimpMySql_Query", () => {
   });
   testPromise("getOneBy (does not return anything)", () => {
     let sql =
-      SqlComposer.Select.(
-        base |> where({j|AND $table.`type_` = ?|j}) |> to_sql
-      );
+      SqlComposer.Select.(base |> where({j|AND $table.`type_` = ?|j}));
     let params = Json.Encode.([|string("groundhog")|] |> jsonArray);
-    PimpMySql_Query.getOneBy(decoder, sql, params, conn)
+    PimpMySql_Query.getOneBy(sql, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -144,11 +140,9 @@ describe("PimpMySql_Query", () => {
   });
   testPromise("get (returns 1 result)", () => {
     let sql =
-      SqlComposer.Select.(
-        base |> where({j|AND $table.`type_` = ?|j}) |> to_sql
-      );
+      SqlComposer.Select.(base |> where({j|AND $table.`type_` = ?|j}));
     let params = Json.Encode.([|string("elephant")|] |> jsonArray);
-    PimpMySql_Query.get(decoder, sql, params, conn)
+    PimpMySql_Query.get(sql, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {
@@ -161,11 +155,9 @@ describe("PimpMySql_Query", () => {
   });
   testPromise("get (does not return anything)", () => {
     let sql =
-      SqlComposer.Select.(
-        base |> where({j|AND $table.`type_` = ?|j}) |> to_sql
-      );
+      SqlComposer.Select.(base |> where({j|AND $table.`type_` = ?|j}));
     let params = Json.Encode.([|string("groundhog")|] |> jsonArray);
-    PimpMySql_Query.get(decoder, sql, params, conn)
+    PimpMySql_Query.get(sql, decoder, params, conn)
     |> Js.Promise.then_(res =>
          (
            switch (res) {

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -1,61 +1,66 @@
-module type Config = {let table: string; let base: SqlComposer.Select.t;};
+module type Config = {
+  type t;
+  let table: string;
+  let decoder: Js.Json.t => t;
+  let base: SqlComposer.Select.t;
+};
 
 module Generator = (Config: Config) => {
   let sqlFactory = PimpMySql_FactorySql.make(Config.table, Config.base);
-  let getOneById = (decoder, id, conn) =>
+  let getOneById = (id, conn) =>
     PimpMySql_Query.getOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
-      decoder,
+      Config.decoder,
       id,
       conn,
     );
-  let getByIdList = (decoder, idList, conn) =>
+  let getByIdList = (idList, conn) =>
     PimpMySql_Query.getByIdList(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
-      decoder,
+      Config.decoder,
       idList,
       conn,
     );
-  let getOneBy = (user, decoder, params, conn) =>
+  let getOneBy = (user, params, conn) =>
     PimpMySql_Query.getOneBy(
-      decoder,
+      Config.decoder,
       SqlComposer.Select.to_sql(sqlFactory(user)),
       params,
       conn,
     );
-  let get = (user, decoder, params, conn) =>
+  let get = (user, params, conn) =>
     PimpMySql_Query.get(
-      decoder,
+      Config.decoder,
       SqlComposer.Select.to_sql(sqlFactory(user)),
       params,
       conn,
     );
-  let insert = (decoder, encoder, record, conn) =>
+  let insert = (encoder, record, conn) =>
     PimpMySql_Query.insert(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
-      decoder,
+      Config.decoder,
       encoder,
       record,
       conn,
     );
-  let updateById = (decoder, encoder, record, id, conn) =>
+  let updateById = (encoder, record, id, conn) =>
     PimpMySql_Query.updateById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
-      decoder,
+      Config.decoder,
       encoder,
       record,
       id,
       conn,
     );
-  let archiveCompoundById = (decoder, id, conn) =>
+  let archiveCompoundById = (id, conn) =>
     PimpMySql_Query.archiveCompoundById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
-      decoder,
+      Config.decoder,
       id,
       conn,
     );

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -37,8 +37,8 @@ module Generator = (Config: Config) => {
       params,
       conn,
     );
-  let insert = (encoder, record, conn) =>
-    PimpMySql_Query.insert(
+  let insertOne = (encoder, record, conn) =>
+    PimpMySql_Query.insertOne(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -7,46 +7,46 @@ module type Config = {
 
 module Generator = (Config: Config) => {
   let sqlFactory = PimpMySql_FactorySql.make(Config.table, Config.base);
-  let getOneById = (id, conn) =>
+  let getOneById = (id, connection) =>
     PimpMySql_Query.getOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       id,
-      conn,
+      connection,
     );
-  let getByIdList = (idList, conn) =>
+  let getByIdList = (idList, connection) =>
     PimpMySql_Query.getByIdList(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       idList,
-      conn,
+      connection,
     );
-  let getOneBy = (user, params, conn) =>
+  let getOneBy = (user, params, connection) =>
     PimpMySql_Query.getOneBy(
+      sqlFactory(user),
       Config.decoder,
-      SqlComposer.Select.to_sql(sqlFactory(user)),
       params,
-      conn,
+      connection,
     );
-  let get = (user, params, conn) =>
+  let get = (user, params, connection) =>
     PimpMySql_Query.get(
+      sqlFactory(user),
       Config.decoder,
-      SqlComposer.Select.to_sql(sqlFactory(user)),
       params,
-      conn,
+      connection,
     );
-  let insertOne = (encoder, record, conn) =>
+  let insertOne = (encoder, record, connection) =>
     PimpMySql_Query.insertOne(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       encoder,
       record,
-      conn,
+      connection,
     );
-  let updateOneById = (encoder, record, id, conn) =>
+  let updateOneById = (encoder, record, id, connection) =>
     PimpMySql_Query.updateOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
@@ -54,14 +54,14 @@ module Generator = (Config: Config) => {
       encoder,
       record,
       id,
-      conn,
+      connection,
     );
-  let archiveCompoundOneById = (id, conn) =>
+  let archiveCompoundOneById = (id, connection) =>
     PimpMySql_Query.archiveCompoundOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       id,
-      conn,
+      connection,
     );
 };

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -1,5 +1,6 @@
 module type Config = {
   type t;
+  let connection: SqlCommon.Make_sql(MySql2).connection;
   let table: string;
   let decoder: Js.Json.t => t;
   let base: SqlComposer.Select.t;
@@ -7,46 +8,46 @@ module type Config = {
 
 module Generator = (Config: Config) => {
   let sqlFactory = PimpMySql_FactorySql.make(Config.table, Config.base);
-  let getOneById = (id, connection) =>
+  let getOneById = id =>
     PimpMySql_Query.getOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       id,
-      connection,
+      Config.connection,
     );
-  let getByIdList = (idList, connection) =>
+  let getByIdList = idList =>
     PimpMySql_Query.getByIdList(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       idList,
-      connection,
+      Config.connection,
     );
-  let getOneBy = (user, params, connection) =>
+  let getOneBy = (user, params) =>
     PimpMySql_Query.getOneBy(
       sqlFactory(user),
       Config.decoder,
       params,
-      connection,
+      Config.connection,
     );
-  let get = (user, params, connection) =>
+  let get = (user, params) =>
     PimpMySql_Query.get(
       sqlFactory(user),
       Config.decoder,
       params,
-      connection,
+      Config.connection,
     );
-  let insertOne = (encoder, record, connection) =>
+  let insertOne = (encoder, record) =>
     PimpMySql_Query.insertOne(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       encoder,
       record,
-      connection,
+      Config.connection,
     );
-  let updateOneById = (encoder, record, id, connection) =>
+  let updateOneById = (encoder, record, id) =>
     PimpMySql_Query.updateOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
@@ -54,14 +55,14 @@ module Generator = (Config: Config) => {
       encoder,
       record,
       id,
-      connection,
+      Config.connection,
     );
-  let archiveCompoundOneById = (id, connection) =>
+  let archiveCompoundOneById = id =>
     PimpMySql_Query.archiveCompoundOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
       id,
-      connection,
+      Config.connection,
     );
 };

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -46,8 +46,8 @@ module Generator = (Config: Config) => {
       record,
       conn,
     );
-  let updateById = (encoder, record, id, conn) =>
-    PimpMySql_Query.updateById(
+  let updateOneById = (encoder, record, id, conn) =>
+    PimpMySql_Query.updateOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,
@@ -56,8 +56,8 @@ module Generator = (Config: Config) => {
       id,
       conn,
     );
-  let archiveCompoundById = (id, conn) =>
-    PimpMySql_Query.archiveCompoundById(
+  let archiveCompoundOneById = (id, conn) =>
+    PimpMySql_Query.archiveCompoundOneById(
       sqlFactory(SqlComposer.Select.select),
       Config.table,
       Config.decoder,

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -24,7 +24,7 @@ module Generator: (Config: Config) => {
     Js.Json.t,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(array(Config.t));
-  let insert: (
+  let insertOne: (
     Json.Encode.encoder('b),
     'b,
     SqlCommon.Make_sql(MySql2).connection

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -1,5 +1,6 @@
 module type Config = {
   type t;
+  let connection: SqlCommon.Make_sql(MySql2).connection;
   let table: string;
   let decoder: Js.Json.t => t;
   let base: SqlComposer.Select.t;
@@ -8,35 +9,28 @@ module type Config = {
 module Generator: (Config: Config) => {
   let getOneById: (
     int,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option(Config.t));
   let getByIdList: (
     list(int),
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(array(Config.t));
   let getOneBy: (
     SqlComposer.Select.t,
     Js.Json.t,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option(Config.t));
   let get: (
     SqlComposer.Select.t,
     Js.Json.t,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(array(Config.t));
   let insertOne: (
     Json.Encode.encoder('b),
     'b,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option(Config.t));
   let updateOneById: (
     Json.Encode.encoder('b),
     'b,
     int,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
   let archiveCompoundOneById: (
     int,
-    SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
 };

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -29,13 +29,13 @@ module Generator: (Config: Config) => {
     'b,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(option(Config.t));
-  let updateById: (
+  let updateOneById: (
     Json.Encode.encoder('b),
     'b,
     int,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
-  let archiveCompoundById: (
+  let archiveCompoundOneById: (
     int,
     SqlCommon.Make_sql(MySql2).connection
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -1,47 +1,42 @@
 module type Config = {
+  type t;
   let table: string;
+  let decoder: Js.Json.t => t;
   let base: SqlComposer.Select.t;
 };
 
 module Generator: (Config: Config) => {
   let getOneById: (
-    Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(option('a));
+  ) => Js.Promise.t(option(Config.t));
   let getByIdList: (
-    Js.Json.t => 'a,
     list(int),
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(array('a));
+  ) => Js.Promise.t(array(Config.t));
   let getOneBy: (
     SqlComposer.Select.t,
-    Js.Json.t => 'a,
     Js.Json.t,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(option('a));
+  ) => Js.Promise.t(option(Config.t));
   let get: (
     SqlComposer.Select.t,
-    Js.Json.t => 'a,
     Js.Json.t,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(array('a));
+  ) => Js.Promise.t(array(Config.t));
   let insert: (
-    Js.Json.t => 'a,
     Json.Encode.encoder('b),
     'b,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(option('a));
+  ) => Js.Promise.t(option(Config.t));
   let updateById: (
-    Js.Json.t => 'a,
     Json.Encode.encoder('b),
     'b,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(Result.result(exn, option('a)));
+  ) => Js.Promise.t(Result.result(exn, option(Config.t)));
   let archiveCompoundById: (
-    Js.Json.t => 'a,
     int,
     SqlCommon.Make_sql(MySql2).connection
-  ) => Js.Promise.t(Result.result(exn, option('a)));
+  ) => Js.Promise.t(Result.result(exn, option(Config.t)));
 };

--- a/src/PimpMySql_Params.rei
+++ b/src/PimpMySql_Params.rei
@@ -1,3 +1,3 @@
-let named: Js.Json.t => option([> `Named(Js.Json.t) ]);
+let named: Js.Json.t => MySql2.params;
 
-let positional : Js.Json.t => option([> `Positional(Js.Json.t) ]);
+let positional : Js.Json.t => MySql2.params;

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -94,7 +94,7 @@ let updateOneById = (baseQuery, table, decoder, encoder, record, id, conn) => {
          getOneById(baseQuery, table, decoder, id, conn)
          |> Js.Promise.then_(res => Js.Promise.resolve(Result.pure(res)));
        } else {
-         PimpMySql_Error.NotFound("ERROR: updateById failed")
+         PimpMySql_Error.NotFound("ERROR: updateOneById failed")
          |> (x => Result.error(x))
          |> Js.Promise.resolve;
        }
@@ -115,7 +115,7 @@ let archiveCompoundOneById = (baseQuery, table, decoder, id, conn) => {
          getOneById(baseQuery, table, decoder, id, conn)
          |> Js.Promise.then_(res => Js.Promise.resolve(Result.pure(res)));
        } else {
-         PimpMySql_Error.NotFound("ERROR: softCompoundDelete failed")
+         PimpMySql_Error.NotFound("ERROR: archiveCompoundOneById failed")
          |> (x => Result.error(x))
          |> Js.Promise.resolve;
        }

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -9,7 +9,8 @@ let getOneById = (baseQuery, table, decoder, id, conn) => {
     SqlComposer.Select.(
       baseQuery |> where({j|AND $table.`id` = ?|j}) |> to_sql
     );
-  let params = Some(`Positional(Json.Encode.([|int(id)|] |> jsonArray)));
+  let params =
+    Json.Encode.([|int(id)|] |> jsonArray) |> PimpMySql_Params.positional;
   Sql.Promise.query(conn, ~sql, ~params?, ())
   |> Js.Promise.then_(result =>
        PimpMySql_Decode.oneRow(decoder, result) |> Js.Promise.resolve

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -78,7 +78,7 @@ let insertBatch =
        )
   };
 
-let updateById = (baseQuery, table, decoder, encoder, record, id, conn) => {
+let updateOneById = (baseQuery, table, decoder, encoder, record, id, conn) => {
   let params =
     Json.Encode.(
       [|encoder @@ record, int @@ id|]
@@ -99,9 +99,9 @@ let updateById = (baseQuery, table, decoder, encoder, record, id, conn) => {
      );
 };
 
-let archiveCompoundById = (baseQuery, table, decoder, id, conn) => {
+let archiveCompoundOneById = (baseQuery, table, decoder, id, conn) => {
   let params =
-    Json.Encode.([|int @@ id|] |> jsonArray |> PimpMySql_Params.positional);
+    Json.Encode.([|int @@ id|] |> jsonArray) |> PimpMySql_Params.positional;
   let sql = {j|
     UPDATE $table
     SET $table.`deleted` = 1, $table.`deleted_timestamp` = NOW()

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -30,7 +30,8 @@ let getByIdList = (baseQuery, table, decoder, idList, conn) => {
      );
 };
 
-let getOneBy = (decoder, sql, params, conn) => {
+let getOneBy = (baseQuery, decoder, params, conn) => {
+  let sql = SqlComposer.Select.to_sql(baseQuery);
   let params = PimpMySql_Params.positional(params);
   Sql.Promise.query(conn, ~sql, ~params?, ())
   |> Js.Promise.then_(result =>
@@ -38,7 +39,8 @@ let getOneBy = (decoder, sql, params, conn) => {
      );
 };
 
-let get = (decoder, sql, params, conn) => {
+let get = (baseQuery, decoder, params, conn) => {
+  let sql = SqlComposer.Select.to_sql(baseQuery);
   let params = PimpMySql_Params.positional(params);
   Sql.Promise.query(conn, ~sql, ~params?, ())
   |> Js.Promise.then_(result =>

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -106,7 +106,7 @@ let archiveCompoundOneById = (baseQuery, table, decoder, id, conn) => {
     Json.Encode.([|int @@ id|] |> jsonArray) |> PimpMySql_Params.positional;
   let sql = {j|
     UPDATE $table
-    SET $table.`deleted` = 1, $table.`deleted_timestamp` = NOW()
+    SET $table.`deleted` = 1, $table.`deleted_timestamp` = UNIX_TIMESTAMP()
     WHERE $table.`id` = ?
   |j};
   Sql.Promise.mutate(conn, ~sql, ~params?, ())

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -46,7 +46,7 @@ let get = (decoder, sql, params, conn) => {
      );
 };
 
-let insert = (baseQuery, table, decoder, encoder, record, conn) => {
+let insertOne = (baseQuery, table, decoder, encoder, record, conn) => {
   let params =
     [|record|] |> Json.Encode.array(encoder) |> PimpMySql_Params.positional;
   let sql = {j|INSERT INTO $table SET ?|j};

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -48,7 +48,7 @@ let insertBatch: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result('c, array('b)));
 
-let updateById: (
+let updateOneById: (
   SqlComposer.Select.t,
   string,
   Js.Json.t => 'a,
@@ -58,7 +58,7 @@ let updateById: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
 
-let archiveCompoundById: (
+let archiveCompoundOneById: (
   SqlComposer.Select.t,
   string,
   Js.Json.t => 'a,

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -15,15 +15,15 @@ let getByIdList: (
 ) => Js.Promise.t(array('a));
   
 let getOneBy: (
+  SqlComposer.Select.t,
   Js.Json.t => 'a,
-  string,
   Js.Json.t,
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(option('a));
 
 let get: (
+  SqlComposer.Select.t,
   Js.Json.t => 'a,
-  string,
   Js.Json.t,
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(array('a));

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -28,7 +28,7 @@ let get: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(array('a));
 
-let insert: (
+let insertOne: (
   SqlComposer.Select.t,
   string,
   Js.Json.t => 'a,


### PR DESCRIPTION
## Summary of the major changes in this PR:

- Update: refactored `TestPimpMySqlQuery.re`.
- Update: refactored Config in FactoryModel.
- Update: updated `README.md`.
- Update: refactored `PimpMySql_Params.rei`.
- Update: refactored `PimpMySql_Query.re`.
- Update: renamed updateById to updateOneById
- Update: renamed archiveCompoundById to archiveCompoundOneById.
- Update: renamed insert to insertOne.
- Update: refactored get and getOneBy.
- Update: changed deleted_timestamp to unix timestamp for the archiveCompoundOneById function in `src/PimpMySql_Query.re`.



