### PR TITLE
[DELIVERS #157235937, #157208443] deleteOneById

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Everything not checked...
   - [ ] Archive
     - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
     - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
+    - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
+          `ArchiveCompound` interface
     - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row using the `id` column - must fit the
           `ArchiveCompound` and `PrimaryId` interfaces
   - [ ] SELECT
@@ -149,6 +151,8 @@ Everything not checked...
     - [ ] Archive
       - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
       - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
+      - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
+            `ArchiveCompound` interface
       - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row using the `id` column - must fit the
             `ArchiveCompound` and `PrimaryId` interfaces
     - [ ] SELECT

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Everything not checked...
     - [ ] _(increment)_ increment an integer column - must fit the `Counter` interface
   - [ ] DELETE
     - [ ] _(delete)_ using a custom where clause
-    - [ ] _(deleteById)_ - must fit the `PrimaryId` interface
+    - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
   - [ ] Archive
     - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
     - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
@@ -145,7 +145,7 @@ Everything not checked...
       - [ ] _(increment)_ increment an integer column - must fit the `Counter` interface
     - [ ] DELETE
       - [ ] _(delete)_ using a custom where clause
-      - [ ] _(deleteById)_ - must fit the `PrimaryId` interface
+      - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
     - [ ] Archive
       - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
       - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -337,6 +337,30 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
+  testPromise("delteOneById (returns 1 result)", () =>
+    Model.deleteOneById(3)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok({id: 3, type_: "elephant", deleted: 0}) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
+  testPromise("delteOneById (does not return anything)", () =>
+    Model.deleteOneById(3)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -329,6 +329,25 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        );
   });
+  testPromise("updateOneById (succeeds but returns no result)", () => {
+    let encoder = x =>
+      [
+        ("type_", Json.Encode.string @@ x.type_),
+        ("deleted", Json.Encode.int @@ 1),
+      ]
+      |> Json.Encode.object_;
+    let record = {type_: "chicken"};
+    Model2.updateOneById(encoder, record, 1)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok(None) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   testPromise("updateOneById (does not return a result)", () => {
     let encoder = x =>
       [("type_", Json.Encode.string @@ x.type_)] |> Json.Encode.object_;

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -386,6 +386,18 @@ describe("PimpMySql_FactoryModel", () => {
          |> Js.Promise.resolve
        )
   );
+  testPromise("archiveCompoundOneById (succeeds but returns no result)", () =>
+    Model2.archiveCompoundOneById(3)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok(None) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
   testPromise("archiveCompoundOneById (does not return a result)", () =>
     Model.archiveCompoundOneById(99)
     |> Js.Promise.then_(res =>
@@ -403,7 +415,7 @@ describe("PimpMySql_FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Ok({id: 3, type_: "elephant", deleted: 0}) => pass
+           | Result.Ok({id: 3, type_: "elephant", deleted: 1}) => pass
            | _ => fail("not an expected result")
            }
          )

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -423,6 +423,71 @@ describe("PimpMySql_Query", () => {
        )
     |> Js.Promise.catch((_) => Js.Promise.resolve @@ pass);
   });
+  testPromise("archiveCompoundBy (returns 1 result)", () => {
+    let where = [{j|AND $table.`type_` = ?|j}];
+    let params = Json.Encode.([|string("catfish")|] |> jsonArray);
+    PimpMySql_Query.archiveCompoundBy(
+      base,
+      where,
+      table,
+      decoder,
+      params,
+      conn,
+    )
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok([|{id: 7, type_: "catfish", deleted: 1}|]) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
+  testPromise("archiveCompoundBy (succeeds but returns no result)", () => {
+    let base =
+      base |> SqlComposer.Select.where({j|AND $table.`deleted` = 0|j});
+    let where = [{j|AND $table.`type_` = ?|j}];
+    let params = Json.Encode.([|string("lumpsucker")|] |> jsonArray);
+    PimpMySql_Query.archiveCompoundBy(
+      base,
+      where,
+      table,
+      decoder,
+      params,
+      conn,
+    )
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok([||]) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
+  testPromise("archiveCompoundBy (fails and does not return anything)", () => {
+    let where = [{j|AND $table.`type_` = ?|j}];
+    let params = Json.Encode.([|string("blahblahblah")|] |> jsonArray);
+    PimpMySql_Query.archiveCompoundBy(
+      base,
+      where,
+      table,
+      decoder,
+      params,
+      conn,
+    )
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   testPromise("archiveCompoundOneById (returns 1 result)", () =>
     PimpMySql_Query.archiveCompoundOneById(base, table, decoder, 2, conn)
     |> Js.Promise.then_(res =>

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -220,6 +220,27 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
+  testPromise("insertOne (succeeds but returns no result)", () => {
+    let base =
+      base |> SqlComposer.Select.where({j|AND $table.`deleted` = 0|j});
+    let record = {type_: "turkey"};
+    let encoder = x =>
+      [
+        ("type_", Json.Encode.string @@ x.type_),
+        ("deleted", Json.Encode.int @@ 1),
+      ]
+      |> Json.Encode.object_;
+    PimpMySql_Query.insertOne(base, table, decoder, encoder, record, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | None => pass
+           | Some(_) => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   testPromise("insertOne (fails and throws unique constraint error)", () => {
     let record = {type_: "elephant"};
     let encoder = x =>
@@ -398,7 +419,7 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("delteOneById (returns 1 result)", () =>
+  testPromise("deleteOneById (returns 1 result)", () =>
     PimpMySql_Query.deleteOneById(base, table, decoder, 3, conn)
     |> Js.Promise.then_(res =>
          (
@@ -410,7 +431,7 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        )
   );
-  testPromise("delteOneById (fails and does not return anything)", () =>
+  testPromise("deleteOneById (fails and does not return anything)", () =>
     PimpMySql_Query.deleteOneById(base, table, decoder, 99, conn)
     |> Js.Promise.then_(res =>
          (

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -435,6 +435,20 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        )
   );
+  testPromise("archiveCompoundOneById (succeeds but returns no result)", () => {
+    let base =
+      base |> SqlComposer.Select.where({j|AND $table.`deleted` = 0|j});
+    PimpMySql_Query.archiveCompoundOneById(base, table, decoder, 3, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok(None) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   testPromise(
     "archiveCompoundOneById (fails and does not return anything)", () =>
     PimpMySql_Query.archiveCompoundOneById(base, table, decoder, 99, conn)
@@ -453,7 +467,7 @@ describe("PimpMySql_Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
-           | Result.Ok({id: 3, type_: "elephant", deleted: 0}) => pass
+           | Result.Ok({id: 3, type_: "elephant", deleted: 1}) => pass
            | _ => fail("not an expected result")
            }
          )

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -398,6 +398,30 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        )
   );
+  testPromise("delteOneById (returns 1 result)", () =>
+    PimpMySql_Query.deleteOneById(base, table, decoder, 3, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok({id: 3, type_: "elephant", deleted: 0}) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
+  testPromise("delteOneById (fails and does not return anything)", () =>
+    PimpMySql_Query.deleteOneById(base, table, decoder, 99, conn)
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Error(PimpMySql_Error.NotFound(_)) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       )
+  );
   afterAll(() => {
     Sql.mutate(conn, ~sql=dropDb, (_) => ());
     MySql2.close(conn);

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -353,6 +353,35 @@ describe("PimpMySql_Query", () => {
          |> Js.Promise.resolve
        );
   });
+  testPromise("updateOneById (succeeds but returns no result)", () => {
+    let base =
+      base |> SqlComposer.Select.where({j|AND $table.`deleted` = 0|j});
+    let record = {type_: "chicken"};
+    let encoder = x =>
+      [
+        ("type_", Json.Encode.string @@ x.type_),
+        ("deleted", Json.Encode.int @@ 1),
+      ]
+      |> Json.Encode.object_;
+    PimpMySql_Query.updateOneById(
+      base,
+      table,
+      decoder,
+      encoder,
+      record,
+      1,
+      conn,
+    )
+    |> Js.Promise.then_(res =>
+         (
+           switch (res) {
+           | Result.Ok(None) => pass
+           | _ => fail("not an expected result")
+           }
+         )
+         |> Js.Promise.resolve
+       );
+  });
   testPromise("updateOneById (fails and does not return anything)", () => {
     let record = {type_: "goose"};
     let encoder = x =>

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -65,6 +65,15 @@ module Generator = (Config: Config) => {
       id,
       Config.connection,
     );
+  let archiveCompoundBy = (user, params) =>
+    PimpMySql_Query.archiveCompoundBy(
+      sqlFactory(SqlComposer.Select.select),
+      user,
+      Config.table,
+      Config.decoder,
+      params,
+      Config.connection,
+    );
   let archiveCompoundOneById = id =>
     PimpMySql_Query.archiveCompoundOneById(
       sqlFactory(SqlComposer.Select.select),

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -73,4 +73,12 @@ module Generator = (Config: Config) => {
       id,
       Config.connection,
     );
+  let deleteOneById = id =>
+    PimpMySql_Query.deleteOneById(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      Config.decoder,
+      id,
+      Config.connection,
+    );
 };

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -34,6 +34,10 @@ module Generator: (Config: Config) => {
     'b,
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
+  let archiveCompoundBy: (
+    list(string),
+    Js.Json.t,
+  ) => Js.Promise.t(Result.result(exn, array(Config.t)));
   let archiveCompoundOneById: (
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -37,4 +37,7 @@ module Generator: (Config: Config) => {
   let archiveCompoundOneById: (
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
+  let deleteOneById: (
+    int,
+  ) => Js.Promise.t(Result.result(exn, Config.t));
 };

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -174,7 +174,7 @@ let deleteOneById = (baseQuery, table, decoder, id, conn) => {
   |j};
   let params =
     Json.Encode.([|int @@ id|] |> jsonArray) |> PimpMySql_Params.positional;
-  log("deleteById", sql, params);
+  log("deleteOneById", sql, params);
   getOneById(baseQuery, table, decoder, id, conn)
   |> Js.Promise.then_(res =>
        switch (res) {
@@ -182,7 +182,7 @@ let deleteOneById = (baseQuery, table, decoder, id, conn) => {
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
          |> Js.Promise.then_((_) => Js.Promise.resolve(Result.pure(x)))
        | None =>
-         PimpMySql_Error.NotFound("ERROR: deleteById failed")
+         PimpMySql_Error.NotFound("ERROR: deleteOneById failed")
          |> (x => Result.error(x))
          |> Js.Promise.resolve
        }

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -66,6 +66,15 @@ let updateOneById: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
 
+let archiveCompoundBy: (
+  SqlComposer.Select.t,
+  list(string),
+  string,
+  Js.Json.t => 'a,
+  Js.Json.t,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(Result.result(exn, array('a)));
+
 let archiveCompoundOneById: (
   SqlComposer.Select.t,
   string,

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -73,3 +73,11 @@ let archiveCompoundOneById: (
   int,
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
+
+let deleteOneById: (
+  SqlComposer.Select.t,
+  string,
+  Js.Json.t => 'a,
+  int,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(Result.result(exn, 'a));


### PR DESCRIPTION
# SUPERSET OF THE FOLLOWING PR: https://github.com/scull7/bs-pimp-my-sql/pull/17

## Summary of the major changes in this PR:

- New: added deleteOneById in `src/PimpMySql_Query.re`.
- New: added deleteOneById in `src/PimpMySql_Query.rei`.
- New: added test coverage for deleteOneById in `__tests__/TestPimpMySqlQuery.re`.
- New: added deleteOneById in `src/PimpMySql_FactoryModel.re`.
- New: added deleteOneById in `src/PimpMySql_FactoryModel.rei`.
- New: added test coverage for deleteOneById in `__tests__/TestPimpMySqlFactoryModel.re`.
- Update: made changes to archiveCompoundOneById; the function will now verify that only 1 row will be affected before doing any mutations.
- Update: made changes to updateOneById; the function will now verify that only 1 row will be affected before doing any mutations.
- Update: updated deleteOneById in `README.md`.
