### PR TITLE
[DELIVERS #157235937, #157208443]  archiveOneById

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Everything not checked...
     - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
   - [ ] Archive
     - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
-    - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
+    - [x] _(archiveOneById)_ Soft DELETE a row using the `id` column - must fit the `Archive` interface
     - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
           `ArchiveCompound` interface
     - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row using the `id` column - must fit the
@@ -150,7 +150,7 @@ Everything not checked...
       - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
     - [ ] Archive
       - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
-      - [ ] _(archive)_ Soft DELETE a row - must fit the `Archive` interface
+      - [x] _(archiveOneById)_ Soft DELETE a row using the `id` column - must fit the `Archive` interface
       - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
             `ArchiveCompound` interface
       - [x] _(archiveCompoundOneById)_ Soft Compound DELETE a row using the `id` column - must fit the

--- a/__tests__/TestPimpMySqlFactoryModel.re
+++ b/__tests__/TestPimpMySqlFactoryModel.re
@@ -5,6 +5,7 @@ type animal = {
   id: int,
   type_: string,
   deleted: int,
+  deleted_timestamp: int,
 };
 
 type animalInternal = {type_: string};
@@ -83,6 +84,7 @@ module AnimalConfig = {
       id: field("id", int, json),
       type_: field("type_", string, json),
       deleted: field("deleted", int, json),
+      deleted_timestamp: field("deleted_timestamp", int, json),
     };
   let base =
     SqlComposer.Select.(
@@ -90,6 +92,7 @@ module AnimalConfig = {
       |> field({j|$table.`id`|j})
       |> field({j|$table.`type_`|j})
       |> field({j|$table.`deleted`|j})
+      |> field({j|$table.`deleted_timestamp`|j})
       |> order_by(`Desc({j|$table.`id`|j}))
     );
 };
@@ -103,6 +106,7 @@ module AnimalConfig2 = {
       id: field("id", int, json),
       type_: field("type_", string, json),
       deleted: field("deleted", int, json),
+      deleted_timestamp: field("deleted_timestamp", int, json),
     };
   let base =
     SqlComposer.Select.(
@@ -110,6 +114,7 @@ module AnimalConfig2 = {
       |> field({j|$table.`id`|j})
       |> field({j|$table.`type_`|j})
       |> field({j|$table.`deleted`|j})
+      |> field({j|$table.`deleted_timestamp`|j})
       |> where({j|AND $table.`deleted` = 0|j})
       |> order_by(`Desc({j|$table.`id`|j}))
     );
@@ -486,6 +491,10 @@ describe("PimpMySql_FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok([|
+               {id: 4, type_: "dogfish", deleted: 1, deleted_timestamp: 0},
+             |]) =>
+             fail("not an expected result")
            | Result.Ok([|{id: 4, type_: "dogfish", deleted: 1}|]) => pass
            | _ => fail("not an expected result")
            }
@@ -526,6 +535,10 @@ describe("PimpMySql_FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok(
+               Some({id: 2, type_: "cat", deleted: 1, deleted_timestamp: 0}),
+             ) =>
+             fail("not an expected result")
            | Result.Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
@@ -562,6 +575,13 @@ describe("PimpMySql_FactoryModel", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok({
+               id: 3,
+               type_: "elephant",
+               deleted: 1,
+               deleted_timestamp: 0,
+             }) =>
+             fail("not an expected result")
            | Result.Ok({id: 3, type_: "elephant", deleted: 1}) => pass
            | _ => fail("not an expected result")
            }

--- a/__tests__/TestPimpMySqlQuery.re
+++ b/__tests__/TestPimpMySqlQuery.re
@@ -5,6 +5,7 @@ type animalExternal = {
   id: int,
   type_: string,
   deleted: int,
+  deleted_timestamp: int,
 };
 
 type animalInternal = {type_: string};
@@ -83,6 +84,7 @@ describe("PimpMySql_Query", () => {
       id: field("id", int, json),
       type_: field("type_", string, json),
       deleted: field("deleted", int, json),
+      deleted_timestamp: field("deleted_timestamp", int, json),
     };
   let decoder2 = json =>
     Json.Decode.{
@@ -509,6 +511,10 @@ describe("PimpMySql_Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok([|
+               {id: 7, type_: "catfish", deleted: 1, deleted_timestamp: 0},
+             |]) =>
+             fail("not an expected result")
            | Result.Ok([|{id: 7, type_: "catfish", deleted: 1}|]) => pass
            | _ => fail("not an expected result")
            }
@@ -565,6 +571,10 @@ describe("PimpMySql_Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok(
+               Some({id: 2, type_: "cat", deleted: 1, deleted_timestamp: 0}),
+             ) =>
+             fail("not an expected result")
            | Result.Ok(Some({id: 2, type_: "cat", deleted: 1})) => pass
            | _ => fail("not an expected result")
            }
@@ -604,6 +614,13 @@ describe("PimpMySql_Query", () => {
     |> Js.Promise.then_(res =>
          (
            switch (res) {
+           | Result.Ok({
+               id: 3,
+               type_: "elephant",
+               deleted: 1,
+               deleted_timestamp: 0,
+             }) =>
+             fail("not an expected result")
            | Result.Ok({id: 3, type_: "elephant", deleted: 1}) => pass
            | _ => fail("not an expected result")
            }

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -65,6 +65,14 @@ module Generator = (Config: Config) => {
       id,
       Config.connection,
     );
+  let archiveOneById = id =>
+    PimpMySql_Query.archiveOneById(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      Config.decoder,
+      id,
+      Config.connection,
+    );
   let archiveCompoundBy = (user, params) =>
     PimpMySql_Query.archiveCompoundBy(
       sqlFactory(SqlComposer.Select.select),

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -34,6 +34,9 @@ module Generator: (Config: Config) => {
     'b,
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
+  let archiveOneById: (
+    int,
+  ) => Js.Promise.t(Result.result(exn, option(Config.t)));
   let archiveCompoundBy: (
     list(string),
     Js.Json.t,

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -139,6 +139,34 @@ let updateOneById = (baseQuery, table, decoder, encoder, record, id, conn) => {
      );
 };
 
+let archiveOneById = (baseQuery, table, decoder, id, conn) => {
+  let sql = {j|
+    UPDATE $table
+    SET $table.`deleted` = UNIX_TIMESTAMP()
+    WHERE $table.`id` = ?
+  |j};
+  let params =
+    Json.Encode.([|int @@ id|] |> jsonArray) |> PimpMySql_Params.positional;
+  log("archiveOneById", sql, params);
+  getOneById(baseQuery, table, decoder, id, conn)
+  |> Js.Promise.then_(res =>
+       switch (res) {
+       | Some(_) =>
+         Sql.Promise.mutate(conn, ~sql, ~params?, ())
+         |> Js.Promise.then_((_) =>
+              getOneById(baseQuery, table, decoder, id, conn)
+              |> Js.Promise.then_(res =>
+                   Js.Promise.resolve(Result.pure(res))
+                 )
+            )
+       | None =>
+         PimpMySql_Error.NotFound("ERROR: archiveOneById failed")
+         |> (x => Result.error(x))
+         |> Js.Promise.resolve
+       }
+     );
+};
+
 let archiveCompoundBy = (baseQuery, userQuery, table, decoder, params, conn) => {
   let where = String.concat(" ", userQuery);
   let sql = {j|

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -66,6 +66,14 @@ let updateOneById: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
 
+let archiveOneById: (
+  SqlComposer.Select.t,
+  string,
+  Js.Json.t => 'a,
+  int,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(Result.result(exn, option('a)));
+
 let archiveCompoundBy: (
   SqlComposer.Select.t,
   list(string),


### PR DESCRIPTION
# SUPERSET OF THE FOLLOWING PR: https://github.com/scull7/bs-pimp-my-sql/pull/19

## Summary of the major changes in this PR:

- New: added archiveOneById in `src/PimpMySql_Query.re`.
- New: added archiveOneById in `src/PimpMySql_Query.rei`.
- New: added test coverage for archiveOneById in `__tests__/TestPimpMySqlQuery.re`.
- New: added archiveOneById in `src/PimpMySql_FactoryModel.re`.
- New: added archiveOneById in `src/PimpMySql_FactoryModel.rei`.
- New: added test coverage for archiveOneById in `__tests__/TestPimpMySqlFactoryModel.re`.
- Update: updated archive in `README.md`.