### PR TITLE
[DELIVERS #157235937, #157208443] deactivateOneById

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Everything not checked...
   - [ ] DELETE
     - [ ] _(delete)_ using a custom where clause
     - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
-  - [ ] Archive
-    - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
+  - [x] Archive
+    - [x] _(deactivateOneById)_ Deactivate a row using the `id` column - must fit the `Activated` and
+          `PrimaryId` interfaces
     - [x] _(archiveOneById)_ Soft DELETE a row using the `id` column - must fit the `Archive` interface
     - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
           `ArchiveCompound` interface
@@ -148,8 +149,9 @@ Everything not checked...
     - [ ] DELETE
       - [ ] _(delete)_ using a custom where clause
       - [x] _(deleteOneById)_ - must fit the `PrimaryId` interface
-    - [ ] Archive
-      - [ ] _(deactivate)_ Deactivate a row - must fit the `Activated` interface
+    - [x] Archive
+      - [x] _(deactivateOneById)_ Deactivate a row using the `id` column - must fit the `Activated` and
+            `PrimaryId` interfaces
       - [x] _(archiveOneById)_ Soft DELETE a row using the `id` column - must fit the `Archive` interface
       - [x] _(archiveCompoundBy)_ Soft Compound DELETE using a custom where clause - must fit the
             `ArchiveCompound` interface

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@glennsl/bs-json": "^1.2.0",
     "bs-mysql2": "^3.1.0",
     "bs-node-debug": "^0.2.0",
-    "bs-result": "^1.0.0",
+    "bs-result": "^1.1.0",
     "bs-sql-common": "^1.0.1",
     "bs-sql-composer": "^1.0.0"
   },

--- a/src/PimpMySql_FactoryModel.re
+++ b/src/PimpMySql_FactoryModel.re
@@ -65,6 +65,14 @@ module Generator = (Config: Config) => {
       id,
       Config.connection,
     );
+  let deactivateOneById = id =>
+    PimpMySql_Query.deactivateOneById(
+      sqlFactory(SqlComposer.Select.select),
+      Config.table,
+      Config.decoder,
+      id,
+      Config.connection,
+    );
   let archiveOneById = id =>
     PimpMySql_Query.archiveOneById(
       sqlFactory(SqlComposer.Select.select),

--- a/src/PimpMySql_FactoryModel.rei
+++ b/src/PimpMySql_FactoryModel.rei
@@ -34,6 +34,9 @@ module Generator: (Config: Config) => {
     'b,
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));
+  let deactivateOneById: (
+    int,
+  ) => Js.Promise.t(Result.result(exn, option(Config.t)));
   let archiveOneById: (
     int,
   ) => Js.Promise.t(Result.result(exn, option(Config.t)));

--- a/src/PimpMySql_Query.re
+++ b/src/PimpMySql_Query.re
@@ -127,14 +127,11 @@ let updateOneById = (baseQuery, table, decoder, encoder, record, id, conn) => {
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
          |> Js.Promise.then_((_) =>
               getOneById(baseQuery, table, decoder, id, conn)
-              |> Js.Promise.then_(res =>
-                   Js.Promise.resolve(Result.pure(res))
-                 )
             )
+         |> Js.Promise.then_(Result.Promise.pure)
        | None =>
          PimpMySql_Error.NotFound("ERROR: updateOneById failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        }
      );
 };
@@ -155,14 +152,11 @@ let deactivateOneById = (baseQuery, table, decoder, id, conn) => {
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
          |> Js.Promise.then_((_) =>
               getOneById(baseQuery, table, decoder, id, conn)
-              |> Js.Promise.then_(res =>
-                   Js.Promise.resolve(Result.pure(res))
-                 )
             )
+         |> Js.Promise.then_(Result.Promise.pure)
        | None =>
          PimpMySql_Error.NotFound("ERROR: deactivateOneById failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        }
      );
 };
@@ -183,14 +177,11 @@ let archiveOneById = (baseQuery, table, decoder, id, conn) => {
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
          |> Js.Promise.then_((_) =>
               getOneById(baseQuery, table, decoder, id, conn)
-              |> Js.Promise.then_(res =>
-                   Js.Promise.resolve(Result.pure(res))
-                 )
             )
+         |> Js.Promise.then_(Result.Promise.pure)
        | None =>
          PimpMySql_Error.NotFound("ERROR: archiveOneById failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        }
      );
 };
@@ -209,16 +200,13 @@ let archiveCompoundBy = (baseQuery, userQuery, table, decoder, params, conn) => 
        switch (res) {
        | [||] =>
          PimpMySql_Error.NotFound("ERROR: archiveCompoundBy failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        | _ =>
          Sql.Promise.mutate(conn, ~sql, ~params=?normalizedParams, ())
          |> Js.Promise.then_((_) =>
               getWhere(baseQuery, userQuery, decoder, params, conn)
-              |> Js.Promise.then_(res =>
-                   Js.Promise.resolve(Result.pure(res))
-                 )
             )
+         |> Js.Promise.then_(Result.Promise.pure)
        }
      );
 };
@@ -239,14 +227,12 @@ let archiveCompoundOneById = (baseQuery, table, decoder, id, conn) => {
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
          |> Js.Promise.then_((_) =>
               getOneById(baseQuery, table, decoder, id, conn)
-              |> Js.Promise.then_(res =>
-                   Js.Promise.resolve(Result.pure(res))
+         )
+              |> Js.Promise.then_(Result.Promise.pure
                  )
-            )
        | None =>
          PimpMySql_Error.NotFound("ERROR: archiveCompoundOneById failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        }
      );
 };
@@ -264,11 +250,10 @@ let deleteOneById = (baseQuery, table, decoder, id, conn) => {
        switch (res) {
        | Some(x) =>
          Sql.Promise.mutate(conn, ~sql, ~params?, ())
-         |> Js.Promise.then_((_) => Js.Promise.resolve(Result.pure(x)))
+         |> Js.Promise.then_((_) => Result.Promise.pure(x))
        | None =>
          PimpMySql_Error.NotFound("ERROR: deleteOneById failed")
-         |> (x => Result.error(x))
-         |> Js.Promise.resolve
+         |> Result.Promise.error
        }
      );
 };

--- a/src/PimpMySql_Query.rei
+++ b/src/PimpMySql_Query.rei
@@ -66,6 +66,14 @@ let updateOneById: (
   SqlCommon.Make_sql(MySql2).connection
 ) => Js.Promise.t(Result.result(exn, option('a)));
 
+let deactivateOneById: (
+  SqlComposer.Select.t,
+  string,
+  Js.Json.t => 'a,
+  int,
+  SqlCommon.Make_sql(MySql2).connection
+) => Js.Promise.t(Result.result(exn, option('a)));
+
 let archiveOneById: (
   SqlComposer.Select.t,
   string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,9 +436,9 @@ bs-node-debug@^0.2.0:
   dependencies:
     debug "^3.1.0"
 
-bs-result@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/bs-result/-/bs-result-1.0.0.tgz#ac163e1384e1529d5f68e1caee16c65ebeb70a98"
+bs-result@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bs-result/-/bs-result-1.1.0.tgz#dcc1e3ca4692ec5fa31df83bf288b5ca2d123e6f"
 
 bs-sql-common@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# SUPERSET OF THE FOLLOWING PR: https://github.com/scull7/bs-pimp-my-sql/pull/20

## Summary of the major changes in this PR:

- New: added deactivateOneById in `src/PimpMySql_Query.re`.
- New: added deactivateOneById in `src/PimpMySql_Query.rei`.
- New: added test coverage for deactivateOneById in `__tests__/TestPimpMySqlQuery.re`.
- New: added deactivateOneById in `src/PimpMySql_FactoryModel.re`.
- New: added deactivateOneById in `src/PimpMySql_FactoryModel.rei`.
- New: added test coverage for deactivateOneById in `__tests__/TestPimpMySqlFactoryModel.re`.
- Update: updated deactivate in `README.md`.
- Update: updated version number for bs-result in `package.json`.
- Update: updated `yarn.lock`.
- Update: refactored `src/PimpMySql_Query.re`.
